### PR TITLE
Add LM Studio local OpenAI-compatible provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,14 @@ This project evolves rapidly — new features, bug fixes, and improvements are s
 ### 🔑 Configure an LLM Provider
 
 1. Open Settings → Karpathy LLM Wiki
-2. Pick a provider from the dropdown (Anthropic, Anthropic Compatible, Google Gemini, OpenAI, DeepSeek, Kimi, GLM, Ollama, OpenRouter, or custom)
-3. Enter your API key (not needed for Ollama)
+2. Pick a provider from the dropdown (Anthropic, Anthropic Compatible, Google Gemini, OpenAI, DeepSeek, Kimi, GLM, Ollama, LM Studio, OpenRouter, or custom)
+3. Enter your API key (not needed for Ollama; optional for LM Studio)
 4. Click **Fetch Models** to populate the model dropdown, or type a model name manually
 5. Click **Test Connection**, then **Save Settings**
 
 **🦙 Ollama (local, no API key):** Install [Ollama](https://ollama.com), pull a model (`ollama pull gemma4`), select "Ollama (Local)" in the provider dropdown.
+
+**LM Studio (local, OpenAI-compatible):** In LM Studio, start the local server and load the model you want to use. In this plugin, select "LM Studio (Local)", set the Base URL to your server address (default `http://localhost:1234/v1`), enter the exact model identifier shown by LM Studio, optionally enter a token if your local endpoint requires one, then click **Test Connection**. **Fetch Models** can populate available IDs from `/v1/models`, but the model field remains freeform so you can use any identifier your local server accepts.
 
 > See [README_CN.md](README_CN.md) for provider-specific instructions in Chinese.
 
@@ -202,7 +204,7 @@ Settings → **Ingestion Acceleration**:
 
 ### 🌐 LLM & Language
 
-- **🔌 Multi-Provider** — Anthropic, Gemini, OpenAI, DeepSeek, Kimi, GLM, OpenRouter, Ollama, MiniMax, custom endpoints — with guided first-run setup and real-time model list fetching
+- **🔌 Multi-Provider** — Anthropic, Gemini, OpenAI, DeepSeek, Kimi, GLM, OpenRouter, Ollama, LM Studio, MiniMax, custom endpoints — with guided first-run setup and real-time model list fetching
 - **🔄 5xx/429/Overload Retry** — Automatic exponential backoff retry (max 2) on HTTP 5xx/429/529 overload errors across all clients, with status-aware error diagnostics
 - **📋 Dynamic Model List** — Real-time fetching from provider APIs
 - **🌐 Wiki Output Language** — 8 languages independent of UI (EN/ZH/JA/KO/DE/FR/ES/PT), with custom input
@@ -302,7 +304,7 @@ This plugin follows Karpathy's philosophy: **feed the LLM full Wiki context, not
 | **Flagship** | Claude Opus 4.7 | 1M tokens | Ultimate quality, higher cost — use selectively |
 | **Flagship** | GPT-5.5 | 1M tokens | Top reasoning, higher cost — use selectively |
 
-For local models (Ollama): context windows are typically smaller (8K–128K). Consider using a cloud provider for ingestion + local model for query.
+For local models (Ollama or LM Studio): context windows are typically smaller than large hosted models and depend on the model you load locally. Consider using a cloud provider for ingestion + local model for query.
 
 **🔌 Anthropic Compatible (Coding Plan):** If your provider offers an Anthropic-compatible API endpoint, select "Anthropic Compatible" and enter your provider's Base URL and API Key.
 

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -371,11 +371,13 @@ export class AnthropicClient implements LLMClient {
 export class OpenAICompatibleClient implements LLMClient {
   private apiKey: string;
   private baseUrl: string;
+  private jsonResponseFormat: 'json_object' | 'json_schema';
 
-  constructor(apiKey: string, baseUrl?: string) {
+  constructor(apiKey: string, baseUrl?: string, options?: { jsonResponseFormat?: 'json_object' | 'json_schema' }) {
     this.apiKey = apiKey;
     this.baseUrl = (baseUrl || 'https://api.openai.com/v1')
       .replace(/\/+$/, '');
+    this.jsonResponseFormat = options?.jsonResponseFormat || 'json_object';
   }
 
   private getHeaders(): Record<string, string> {
@@ -405,7 +407,7 @@ export class OpenAICompatibleClient implements LLMClient {
       messages
     };
     if (params.response_format) {
-      body.response_format = params.response_format;
+      body.response_format = this.getResponseFormat(params.response_format.type);
     }
 
     return withRetry(async () => {
@@ -454,6 +456,23 @@ export class OpenAICompatibleClient implements LLMClient {
 
       return text;
     }, 3, 'OpenAI-compatible API');
+  }
+
+  private getResponseFormat(type: 'json_object'): Record<string, unknown> {
+    if (type === 'json_object' && this.jsonResponseFormat === 'json_schema') {
+      return {
+        type: 'json_schema',
+        json_schema: {
+          name: 'json_response',
+          schema: {
+            type: 'object',
+            additionalProperties: true
+          },
+          strict: false
+        }
+      };
+    }
+    return { type };
   }
 
   async createMessageStream(params: {

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -374,7 +374,8 @@ export class OpenAICompatibleClient implements LLMClient {
 
   constructor(apiKey: string, baseUrl?: string) {
     this.apiKey = apiKey;
-    this.baseUrl = baseUrl || 'https://api.openai.com/v1';
+    this.baseUrl = (baseUrl || 'https://api.openai.com/v1')
+      .replace(/\/+$/, '');
   }
 
   private getHeaders(): Record<string, string> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -206,7 +206,8 @@ export default class LLMWikiPlugin extends Plugin {
 
     // Migrate existing users: if they already have a working config, trust it
     if (savedData && !('llmReady' in savedData)) {
-      const hasConfig = savedData.provider && (savedData.apiKey?.trim() || savedData.provider === 'ollama') && savedData.model;
+      const localProviderNoKeyRequired = savedData.provider === 'ollama' || savedData.provider === 'lm-studio';
+      const hasConfig = savedData.provider && (savedData.apiKey?.trim() || localProviderNoKeyRequired) && savedData.model;
       this.settings.llmReady = !!hasConfig;
       if (hasConfig) {
         console.debug('loadSettings: existing user with config detected, llmReady = true');
@@ -234,7 +235,8 @@ export default class LLMWikiPlugin extends Plugin {
   }
 
   initializeLLMClient() {
-    if (!this.settings.apiKey?.trim() && this.settings.provider !== 'ollama') {
+    const localProviderNoKeyRequired = this.settings.provider === 'ollama' || this.settings.provider === 'lm-studio';
+    if (!this.settings.apiKey?.trim() && !localProviderNoKeyRequired) {
       this.llmClient = null;
       return;
     }
@@ -524,8 +526,8 @@ export default class LLMWikiPlugin extends Plugin {
   async testLLMConnection(): Promise<{ success: boolean; message: string }> {
     const t = TEXTS[this.settings.language] || TEXTS.en;
 
-    const isOllama = this.settings.provider === 'ollama';
-    if (!isOllama && (!this.settings.apiKey || this.settings.apiKey.trim() === '')) {
+    const localProviderNoKeyRequired = this.settings.provider === 'ollama' || this.settings.provider === 'lm-studio';
+    if (!localProviderNoKeyRequired && (!this.settings.apiKey || this.settings.apiKey.trim() === '')) {
       return { success: false, message: t.errorNoApiKey || 'API Key is not configured' };
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,9 @@ function createLLMClient(settings: LLMWikiSettings): LLMClient {
   const providerConfig = PREDEFINED_PROVIDERS[settings.provider];
   const baseUrl = settings.baseUrl?.trim() || providerConfig?.baseUrl || undefined;
   const apiKey = settings.provider === 'ollama' ? 'ollama' : settings.apiKey.trim();
-  return new OpenAICompatibleClient(apiKey, baseUrl);
+  return new OpenAICompatibleClient(apiKey, baseUrl, {
+    jsonResponseFormat: settings.provider === 'lm-studio' ? 'json_schema' : 'json_object'
+  });
 }
 import { TEXTS } from './texts';
 import { slugify, parseFrontmatter } from './utils';

--- a/src/types.ts
+++ b/src/types.ts
@@ -336,6 +336,18 @@ export const PREDEFINED_PROVIDERS: Record<string, ProviderConfig> = {
     apiKeyPlaceholderZh: 'ollama (无需Key)',
     requiresBaseUrl: false
   },
+  'lm-studio': {
+    id: 'lm-studio',
+    name: 'LM Studio (Local)',
+    nameEn: 'LM Studio (Local)',
+    nameZh: 'LM Studio (Local)',
+    baseUrl: 'http://localhost:1234/v1',
+    defaultModel: '',
+    apiKeyPlaceholder: 'Optional token',
+    apiKeyPlaceholderEn: 'Optional token',
+    apiKeyPlaceholderZh: 'Optional token',
+    requiresBaseUrl: false
+  },
   custom: {
     id: 'custom',
     name: 'Custom OpenAI-Compatible',

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -129,6 +129,7 @@ export class LLMWikiSettingTab extends PluginSettingTab {
 
     const providerConfig = PREDEFINED_PROVIDERS[this.tempSettings.provider];
     const isOllama = this.tempSettings.provider === 'ollama';
+    const isLMStudio = this.tempSettings.provider === 'lm-studio';
 
     // Provider Dropdown
     new Setting(containerEl)
@@ -147,6 +148,9 @@ export class LLMWikiSettingTab extends PluginSettingTab {
           const config = PREDEFINED_PROVIDERS[value];
           if (config) {
             this.tempSettings.model = config.defaultModel || '';
+            this.tempSettings.availableModels = [];
+            this.tempSettings.useCustomModel = value === 'lm-studio';
+            if (value === 'lm-studio') this.tempSettings.apiKey = '';
             if (value !== 'custom') this.tempSettings.baseUrl = config.baseUrl;
           }
           this.display();
@@ -157,9 +161,9 @@ export class LLMWikiSettingTab extends PluginSettingTab {
     if (!isOllama) {
       new Setting(containerEl)
         .setName(this.getText('apiKeyName'))
-        .setDesc(this.getText('apiKeyDesc'))
+        .setDesc(isLMStudio ? 'Optional. Leave empty unless your local LM Studio endpoint requires a token.' : this.getText('apiKeyDesc'))
         .addText(text => {
-          text.setPlaceholder(this.getText('apiKeyPlaceholder'))
+          text.setPlaceholder(isLMStudio ? providerConfig?.apiKeyPlaceholder || 'Optional token' : this.getText('apiKeyPlaceholder'))
             .setValue(this.tempSettings.apiKey)
             .onChange((value) => { this.tempSettings.apiKey = value; this.tempSettings.llmReady = false; });
           text.inputEl.type = 'password';
@@ -172,10 +176,12 @@ export class LLMWikiSettingTab extends PluginSettingTab {
     }
 
     // Base URL
-    if (this.tempSettings.provider === 'custom' || this.tempSettings.provider === 'anthropic-compatible' || (providerConfig && this.tempSettings.baseUrl !== providerConfig.baseUrl)) {
+    if (isLMStudio || this.tempSettings.provider === 'custom' || this.tempSettings.provider === 'anthropic-compatible' || (providerConfig && this.tempSettings.baseUrl !== providerConfig.baseUrl)) {
       new Setting(containerEl)
         .setName(this.getText('baseUrlName'))
-        .setDesc(this.tempSettings.provider === 'custom' || this.tempSettings.provider === 'anthropic-compatible'
+        .setDesc(isLMStudio
+          ? 'LM Studio OpenAI-compatible server URL. Include /v1 unless your server is configured differently.'
+          : this.tempSettings.provider === 'custom' || this.tempSettings.provider === 'anthropic-compatible'
           ? this.getText('baseUrlDescCustom') : this.getText('baseUrlDescOverride'))
         .addText(text => text
           .setPlaceholder(providerConfig?.baseUrl || 'https://api.example.com/v1')
@@ -197,11 +203,13 @@ export class LLMWikiSettingTab extends PluginSettingTab {
           button.setDisabled(true);
           try {
             const apiKey = isOllama ? 'ollama' : this.tempSettings.apiKey.trim();
-            const baseUrl = this.tempSettings.baseUrl?.trim() || providerConfig?.baseUrl || undefined;
+            const baseUrl = (this.tempSettings.baseUrl?.trim() || providerConfig?.baseUrl || undefined)?.replace(/\/+$/, '');
 
-            // Smart filter based on provider: OpenRouter allows '/', Ollama allows ':'
+            // Smart filter based on provider. LM Studio model IDs are user-controlled, so do not filter them.
             const getModelFilter = (provider: string) => {
-              if (provider === 'openrouter') {
+              if (provider === 'lm-studio') {
+                return (_id: string) => true;
+              } else if (provider === 'openrouter') {
                 return (id: string) => !id.includes(':'); // Keep '/', filter ':'
               } else if (provider === 'ollama') {
                 return (id: string) => !id.includes('/'); // Keep ':', filter '/'
@@ -239,10 +247,12 @@ export class LLMWikiSettingTab extends PluginSettingTab {
               }
             } else {
               const modelsUrl = (baseUrl || 'https://api.openai.com/v1') + '/models';
+              const headers: Record<string, string> = {};
+              if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
               const response = await requestUrl({
                 url: modelsUrl,
                 method: 'GET',
-                headers: { 'Authorization': `Bearer ${apiKey}` }
+                headers
               });
               const data = response.json as { data?: Array<{ id: string }> };
               if (data.data?.length) {
@@ -251,7 +261,7 @@ export class LLMWikiSettingTab extends PluginSettingTab {
             }
             if (this.tempSettings.availableModels.length > 0) {
               new Notice(this.getText('fetchSuccess').replace('{}', this.tempSettings.availableModels.length.toString()), 5000);
-              if (!this.tempSettings.model || !this.tempSettings.availableModels.includes(this.tempSettings.model)) {
+              if (!isLMStudio && (!this.tempSettings.model || !this.tempSettings.availableModels.includes(this.tempSettings.model))) {
                 this.tempSettings.model = this.tempSettings.availableModels[0];
               }
             } else {
@@ -270,7 +280,7 @@ export class LLMWikiSettingTab extends PluginSettingTab {
         }));
 
     // Model Selection
-    if (this.tempSettings.availableModels && this.tempSettings.availableModels.length > 0 && !this.tempSettings.useCustomModel) {
+    if (!isLMStudio && this.tempSettings.availableModels && this.tempSettings.availableModels.length > 0 && !this.tempSettings.useCustomModel) {
       new Setting(containerEl)
         .setName(this.getText('selectModelName'))
         .setDesc(this.getText('selectModelDesc').replace('{}', this.tempSettings.availableModels.length.toString()))
@@ -287,13 +297,15 @@ export class LLMWikiSettingTab extends PluginSettingTab {
       const useDropdown = (this.tempSettings.availableModels?.length ?? 0) > 0;
       new Setting(containerEl)
         .setName(this.getText('modelName'))
-        .setDesc(this.tempSettings.availableModels?.length
+        .setDesc(isLMStudio
+          ? 'Enter the exact model identifier currently loaded in LM Studio.'
+          : this.tempSettings.availableModels?.length
           ? this.getText('modelDescCustom')
           : providerConfig ? this.getText('modelDescRecommended').replace('{}', providerConfig.defaultModel || '') : this.getText('modelDescManual'))
         .addText(text => text
-          .setPlaceholder(providerConfig?.defaultModel || 'model-name')
+          .setPlaceholder(isLMStudio ? 'Enter model identifier' : providerConfig?.defaultModel || 'model-name')
           .setValue(this.tempSettings.model)
-          .onChange((value) => { this.tempSettings.model = value; }))
+          .onChange((value) => { this.tempSettings.model = value; this.tempSettings.llmReady = false; }))
         .addExtraButton(button => {
           if (useDropdown) {
             button


### PR DESCRIPTION
## Summary

This PR adds LM Studio as a local LLM provider option for Karpathy LLM Wiki.

- Adds `LM Studio (Local)` to the provider registry.
- Adds settings UI support for:
  - editable LM Studio base URL, defaulting to `http://localhost:1234/v1`
  - optional token/key input for local endpoints that require one
  - freeform model identifier input
- Routes LM Studio through the existing OpenAI-compatible request and streaming client path.
- Keeps model selection fully user-controlled, with no hard-coded LM Studio model names.
- Updates the README with basic LM Studio setup instructions.

## Implementation Notes

LM Studio exposes an OpenAI-compatible local API, so this implementation reuses the existing OpenAI-compatible client behavior instead of adding a separate request stack.

The provider configuration adds `lm-studio` with a local default base URL and an empty default model. The model field remains freeform because LM Studio users may load any local model and the plugin should not assume or hard-code model identifiers.

The settings panel treats LM Studio similarly to other local providers where an API key is not required, while still allowing an optional token to be provided. When switching to LM Studio, any previous provider API key is cleared so the optional token field starts empty. Fetching models from `/v1/models` is supported, but fetched results do not overwrite the manually entered model identifier for LM Studio.

Trailing slashes are normalized from OpenAI-compatible base URLs before request construction to avoid malformed endpoint URLs.

## Test Plan

Verified locally with:

- `npm run build`
- `npm run lint`
- `npm test`

Result: TypeScript build completed successfully, lint completed successfully, and the test suite passed with 113 tests.

## Attribution

Implemented by Ivan Ryukendo in collaboration with OpenAI Codex as a software development assistant.

## Maintainer Note

This change is intentionally conservative: LM Studio support is added by extending the existing provider abstraction and OpenAI-compatible API flow. It uses LM Studio's local OpenAI-compatible API and does not include any hard-coded local model names, so users retain full control over the model identifier used by their local LM Studio server.
