### PR TITLE
fix: prevent cross-folder entity/concept duplicates and sharpen classification

### DIFF
--- a/src/wiki/page-factory.ts
+++ b/src/wiki/page-factory.ts
@@ -73,16 +73,19 @@ export class PageFactory {
 
   // Determine the actual file path for a new entity/concept, using slug-based
   // matching first and falling back to LLM semantic resolution.
+  // Returns null when a cross-type collision is detected (same name exists in the
+  // opposite folder) — callers must skip page creation in that case.
   private async resolvePagePath(
     name: string,
     pageType: 'entity' | 'concept',
     summary: string
-  ): Promise<string> {
+  ): Promise<string | null> {
     const folder = pageType === 'entity' ? 'entities' : 'concepts';
+    const otherFolder = pageType === 'entity' ? 'concepts' : 'entities';
     const slug = slugify(name);
     const slugPath = `${this.ctx.settings.wikiFolder}/${folder}/${slug}.md`;
 
-    // Fast path: exact slug match
+    // Fast path: exact slug match (same type folder)
     const existing = await this.ctx.tryReadFile(slugPath);
     if (existing !== null) return slugPath;
 
@@ -111,6 +114,26 @@ export class PageFactory {
       if (slugMatch) {
         await this.appendAliases(slugMatch.path, [name]);
         return slugMatch.path;
+      }
+
+      // Cross-type collision check: if the same name already exists in the opposite
+      // folder, skip creation to prevent entity/concept duplicates across folders.
+      const otherTypePages = allPages.filter(p => p.path.includes(`/${otherFolder}/`));
+      const otherSlugPath = `${this.ctx.settings.wikiFolder}/${otherFolder}/${slug}.md`;
+      const otherExact = await this.ctx.tryReadFile(otherSlugPath);
+      if (otherExact !== null) {
+        console.debug(`Cross-type collision: "${name}" already exists in /${otherFolder}/, skipping duplicate`);
+        await this.appendAliases(otherSlugPath, [name]);
+        return null;
+      }
+      const otherMatch = otherTypePages.find(p =>
+        computeSlug(p.title).toLowerCase() === targetSlug ||
+        (p.aliases || []).some(a => computeSlug(a).toLowerCase() === targetSlug)
+      );
+      if (otherMatch) {
+        console.debug(`Cross-type collision (normalized): "${name}" matched ${otherMatch.path}, skipping duplicate`);
+        await this.appendAliases(otherMatch.path, [name]);
+        return null;
       }
 
       if (sameTypePages.length === 0) return slugPath;
@@ -239,6 +262,10 @@ export class PageFactory {
     console.debug('type:', info.type);
 
     const path = await this.resolvePagePath(info.name, pageType, info.summary);
+    if (path === null) {
+      console.debug(`Skipping ${pageType} "${info.name}": cross-type duplicate exists`);
+      return null;
+    }
     console.debug('Resolved path:', path);
 
     const existingContent = await this.ctx.tryReadFile(path);

--- a/src/wiki/prompts/ingestion.ts
+++ b/src/wiki/prompts/ingestion.ts
@@ -65,7 +65,23 @@ export const INGESTION_PROMPTS = {
 - product: product/tool/software/service. Publications only when they are the primary subject of analysis, not when cited as evidence sources
 - event: event/conference/milestone/historical occurrence
 - location: place/region/geographic concept
-- other: other concrete entities not fitting the concept category
+- other: observable, instantiable concrete things (a specific dataset, benchmark, physical instrument) that do not fit any category above. NOT for abstract ideas, paradigms, or techniques — those are concepts
+
+**Classification Decision Tree (Entity vs. Concept) — apply in order, stop at first match:**
+1. Named PERSON → entity (person)
+2. Named ORGANIZATION, institution, company, team, lab → entity (organization)
+3. Named PROJECT or named initiative → entity (project)
+4. Named LOCATION, place, region → entity (location)
+5. Named EVENT, conference, competition, release milestone → entity (event)
+6. Named PRODUCT with its own vendor/release cycle (specific software package, hardware device, hosted service) → entity (product). Examples: PyTorch, GPT-4, BERT, TensorFlow. BUT if the source is not primarily ABOUT this product, extract its key ideas as concepts instead
+7. Abstract THEORY, principle, hypothesis, cognitive/scientific model → concept (theory)
+8. Procedural METHOD, algorithm, technique, protocol, training procedure → concept (method). Examples: gradient descent, RLHF, fine-tuning, chain-of-thought prompting, backpropagation
+9. Broad TECHNOLOGY paradigm or architectural pattern → concept (technology). Examples: transformer architecture, deep learning, attention mechanism, retrieval-augmented generation
+10. Any TERM, definition, or construct explaining how something works → concept (term)
+11. A concrete named thing that does not fit rules 1–6 → entity (other). Reserve for observable/instantiable things only
+12. If still uncertain → **prefer concept over entity**
+
+**Key boundary**: Named AI models and named frameworks are entities (product). Architectural ideas and learning techniques are concepts (method/technology). When a source mentions a product only as a tool used for something else, extract its role/capabilities as a concept, not the product as an entity.
 
 **Important Rules:**
 - Output ONLY JSON, nothing else


### PR DESCRIPTION
## Summary
- **Cross-folder dedup**: \`resolvePagePath()\` now checks the opposite folder (entities ↔ concepts) after same-type matches fail. When a cross-type collision is found the existing page gets the new name as an alias and creation is skipped — no more duplicate pages for the same topic in both folders.
- **Classification Decision Tree**: Extraction prompt gains a 12-step ordered decision tree for entity vs. concept decisions. \`entity/other\` is now restricted to observable/instantiable things; a "prefer concept over entity" tie-breaker reduces mis-classification of techniques and paradigms.

## Test plan
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm test\` — 165 tests pass
- [x] \`npx tsc --noEmit\` — 0 errors
- [x] \`pnpm build\` — clean exit
- [ ] Manual: ingest two sources that reference the same AI framework — verify only one wiki page is created, second run appends alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)