### PR TITLE
feat: add collision visibility for cross-type duplicate detection

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -455,6 +455,7 @@ export default class LLMWikiPlugin extends Plugin {
         const totalContradictions = reports.reduce((sum, r) => sum + r.contradictionsFound, 0);
         const totalElapsed = reports.reduce((sum, r) => sum + (r.elapsedSeconds || 0), 0);
         const allFailedItems = reports.flatMap(r => r.failedItems);
+        const allCollisions = reports.flatMap(r => r.collisions || []);
         const allSuccess = reports.every(r => r.success);
 
         const aggregated: IngestReport = {
@@ -464,6 +465,7 @@ export default class LLMWikiPlugin extends Plugin {
           entitiesCreated: totalEntities,
           conceptsCreated: totalConcepts,
           failedItems: allFailedItems,
+          collisions: allCollisions,
           contradictionsFound: totalContradictions,
           success: allSuccess,
           elapsedSeconds: totalElapsed,

--- a/src/texts/de.ts
+++ b/src/texts/de.ts
@@ -329,6 +329,7 @@ export const DE_TEXTS = {
     lintStatusBar: 'Prüfung läuft... zum Abbrechen klicken',
     ingestionCancelling: 'Wird abgebrochen — Stopp nach aktuellem Batch',
     ingestionCancelled: 'Aufnahme abgebrochen',
+    crossTypeCollisionNotice: '{count} Einträge als Cross-Type-Alias zusammengeführt (Entity ↔ Concept Duplikate verhindert)',
 
     // Lint Report
     lintReportTitle: 'Wiki-Prüfbericht',

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -332,6 +332,7 @@ export const EN_TEXTS = {
     lintStatusBar: 'Linting... click to cancel',
     ingestionCancelling: 'Cancelling — will stop after current batch completes',
     ingestionCancelled: 'Ingestion cancelled',
+    crossTypeCollisionNotice: '{count} items merged as cross-type aliases (entity ↔ concept duplicates prevented)',
 
     // Lint Report
     lintReportTitle: 'Wiki lint report',

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -329,6 +329,7 @@ export const ES_TEXTS = {
     lintStatusBar: 'Verificando... clic para cancelar',
     ingestionCancelling: 'Cancelando — se detendrá tras el lote actual',
     ingestionCancelled: 'Ingesta cancelada',
+    crossTypeCollisionNotice: '{count} elementos fusionados como alias cross-type (duplicados entidad ↔ concepto evitados)',
 
     // Lint Report
     lintReportTitle: 'Informe de verificación lint de la Wiki',

--- a/src/texts/fr.ts
+++ b/src/texts/fr.ts
@@ -329,6 +329,7 @@ export const FR_TEXTS = {
     lintStatusBar: 'Vérification en cours... cliquer pour annuler',
     ingestionCancelling: 'Annulation — arrêt après le lot en cours',
     ingestionCancelled: 'Ingestion annulée',
+    crossTypeCollisionNotice: '{count} éléments fusionnés comme alias cross-type (doublons entité ↔ concept évités)',
 
     // Lint Report
     lintReportTitle: 'Rapport de vérification du wiki',

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -329,6 +329,7 @@ export const JA_TEXTS = {
     lintStatusBar: 'チェック中... クリックでキャンセル',
     ingestionCancelling: 'キャンセル中 — 現在のバッチ完了後に停止します',
     ingestionCancelled: '取り込みがキャンセルされました',
+    crossTypeCollisionNotice: '{count}件がクロスタイプ別名として統合（エンティティ ↔ コンセプト重複を防止）',
 
     // Lint Report
     lintReportTitle: 'Wiki Lintレポート',

--- a/src/texts/ko.ts
+++ b/src/texts/ko.ts
@@ -330,6 +330,7 @@ export const KO_TEXTS = {
     lintStatusBar: '점검 중... 클릭하여 취소',
     ingestionCancelling: '취소 중 — 현재 배치 완료 후 중지됩니다',
     ingestionCancelled: '수집이 취소되었습니다',
+    crossTypeCollisionNotice: '{count}개 항목이 크로스타입 별칭으로 병합됨（엔티티 ↔ 컨셉 중복 방지）',
 
     // Lint Report
     lintReportTitle: '위키 린트 보고서',

--- a/src/texts/pt.ts
+++ b/src/texts/pt.ts
@@ -329,6 +329,7 @@ export const PT_TEXTS = {
     lintStatusBar: 'Verificando... clique para cancelar',
     ingestionCancelling: 'Cancelando — irá parar após o lote atual',
     ingestionCancelled: 'Ingestão cancelada',
+    crossTypeCollisionNotice: '{count} elementos fundidos como alias cross-type (duplicatas entidade ↔ conceito evitadas)',
 
     // Lint Report
     lintReportTitle: 'Relatório de verificação da Wiki',

--- a/src/texts/zh.ts
+++ b/src/texts/zh.ts
@@ -330,6 +330,7 @@ export const ZH_TEXTS = {
     lintStatusBar: '维护中... 点击取消',
     ingestionCancelling: '正在取消 — 当前批次完成后将停止',
     ingestionCancelled: '提取已取消',
+    crossTypeCollisionNotice: '{count} 个条目合并为跨类型别名（实体 ↔ 概念重复已防止）',
 
     // 维护报告
     lintReportTitle: 'Wiki 维护报告',

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,17 @@ export interface SchemaSuggestion {
 
 // Ingestion report passed to onDone callback
 
+// Result of page creation/update, with optional collision info
+export interface PageCreationResult {
+  path: string | null;
+  collision?: {
+    name: string;
+    sourceType: 'entity' | 'concept';
+    targetType: 'entity' | 'concept';
+    targetPath: string;
+  };
+}
+
 export interface IngestReport {
   sourceFile: string;
   createdPages: string[];
@@ -143,6 +154,7 @@ export interface IngestReport {
   entitiesCreated: number;
   conceptsCreated: number;
   failedItems: Array<{ type: 'entity' | 'concept'; name: string; reason: string }>;
+  collisions: Array<{ name: string; sourceType: 'entity' | 'concept'; targetType: 'entity' | 'concept'; targetPath: string }>;
   contradictionsFound: number;
   success: boolean;
   errorMessage?: string;

--- a/src/wiki/conversation-ingest.ts
+++ b/src/wiki/conversation-ingest.ts
@@ -84,6 +84,7 @@ export class ConversationIngestor {
             entitiesCreated: 0,
             conceptsCreated: 0,
             failedItems: [],
+            collisions: [],
             contradictionsFound: 0,
             success: true,
             errorMessage: 'Knowledge already exists in Wiki',
@@ -224,14 +225,18 @@ CRITICAL RULES:
     parsed.created_pages.push(summaryPath);
 
     const failedItems: Array<{ type: 'entity' | 'concept'; name: string; reason: string }> = [];
+    const collisions: Array<{ name: string; sourceType: 'entity' | 'concept'; targetType: 'entity' | 'concept'; targetPath: string }> = [];
 
     for (const entity of parsed.entities) {
       await this.orch.apiDelay();
       this.ctx.onProgress?.(`Saving entity: ${entity.name}`);
       try {
-        const entityPage = await this.pageFactory.createOrUpdateEntityPage(entity, parsed, { path: summaryPath, basename: semanticSlug }, convPlannedPaths);
-        if (entityPage) {
-          parsed.created_pages.push(entityPage);
+        const entityResult = await this.pageFactory.createOrUpdateEntityPage(entity, parsed, { path: summaryPath, basename: semanticSlug }, convPlannedPaths);
+        if (entityResult.path) {
+          parsed.created_pages.push(entityResult.path);
+        }
+        if (entityResult.collision) {
+          collisions.push(entityResult.collision);
         }
       } catch (error) {
         const reason = error instanceof Error ? error.message : String(error);
@@ -244,9 +249,12 @@ CRITICAL RULES:
       await this.orch.apiDelay();
       this.ctx.onProgress?.(`Saving concept: ${concept.name}`);
       try {
-        const conceptPage = await this.pageFactory.createOrUpdateConceptPage(concept, parsed, { path: summaryPath, basename: semanticSlug }, convPlannedPaths);
-        if (conceptPage) {
-          parsed.created_pages.push(conceptPage);
+        const conceptResult = await this.pageFactory.createOrUpdateConceptPage(concept, parsed, { path: summaryPath, basename: semanticSlug }, convPlannedPaths);
+        if (conceptResult.path) {
+          parsed.created_pages.push(conceptResult.path);
+        }
+        if (conceptResult.collision) {
+          collisions.push(conceptResult.collision);
         }
       } catch (error) {
         const reason = error instanceof Error ? error.message : String(error);
@@ -270,6 +278,7 @@ CRITICAL RULES:
       entitiesCreated,
       conceptsCreated,
       failedItems,
+      collisions,
       contradictionsFound: parsed.contradictions?.length || 0,
       success: true,
       elapsedSeconds: Math.round((Date.now() - startTime) / 1000),

--- a/src/wiki/page-factory.ts
+++ b/src/wiki/page-factory.ts
@@ -7,6 +7,7 @@ import {
   EntityInfo,
   ConceptInfo,
   SourceAnalysis,
+  PageCreationResult,
 } from '../types';
 import { PROMPTS } from '../prompts';
 import {
@@ -73,13 +74,13 @@ export class PageFactory {
 
   // Determine the actual file path for a new entity/concept, using slug-based
   // matching first and falling back to LLM semantic resolution.
-  // Returns null when a cross-type collision is detected (same name exists in the
-  // opposite folder) — callers must skip page creation in that case.
+  // Returns { path: null, collision: {...} } when a cross-type collision is detected
+  // (same name exists in the opposite folder) — callers must skip page creation.
   private async resolvePagePath(
     name: string,
     pageType: 'entity' | 'concept',
     summary: string
-  ): Promise<string | null> {
+  ): Promise<PageCreationResult> {
     const folder = pageType === 'entity' ? 'entities' : 'concepts';
     const otherFolder = pageType === 'entity' ? 'concepts' : 'entities';
     const slug = slugify(name);
@@ -87,7 +88,7 @@ export class PageFactory {
 
     // Fast path: exact slug match (same type folder)
     const existing = await this.ctx.tryReadFile(slugPath);
-    if (existing !== null) return slugPath;
+    if (existing !== null) return { path: slugPath };
 
     // Fast path 2 + Slow path: share sameTypePages across slug-match and LLM resolution
     try {
@@ -113,7 +114,7 @@ export class PageFactory {
       );
       if (slugMatch) {
         await this.appendAliases(slugMatch.path, [name]);
-        return slugMatch.path;
+        return { path: slugMatch.path };
       }
 
       // Cross-type collision check: if the same name already exists in the opposite
@@ -124,7 +125,15 @@ export class PageFactory {
       if (otherExact !== null) {
         console.debug(`Cross-type collision: "${name}" already exists in /${otherFolder}/, skipping duplicate`);
         await this.appendAliases(otherSlugPath, [name]);
-        return null;
+        return {
+          path: null,
+          collision: {
+            name,
+            sourceType: pageType,
+            targetType: otherFolder === 'entities' ? 'entity' : 'concept',
+            targetPath: otherSlugPath
+          }
+        };
       }
       const otherMatch = otherTypePages.find(p =>
         computeSlug(p.title).toLowerCase() === targetSlug ||
@@ -133,10 +142,18 @@ export class PageFactory {
       if (otherMatch) {
         console.debug(`Cross-type collision (normalized): "${name}" matched ${otherMatch.path}, skipping duplicate`);
         await this.appendAliases(otherMatch.path, [name]);
-        return null;
+        return {
+          path: null,
+          collision: {
+            name,
+            sourceType: pageType,
+            targetType: otherFolder === 'entities' ? 'entity' : 'concept',
+            targetPath: otherMatch.path
+          }
+        };
       }
 
-      if (sameTypePages.length === 0) return slugPath;
+      if (sameTypePages.length === 0) return { path: slugPath };
 
       const pagesList = sameTypePages
         .map(p => {
@@ -148,7 +165,7 @@ export class PageFactory {
         .join('\n');
 
       const client = this.ctx.getClient();
-      if (!client) return slugPath;
+      if (!client) return { path: slugPath };
 
       const prompt = PROMPTS.resolveEntityDedup
         .replace('{{entity_name}}', name)
@@ -174,13 +191,13 @@ export class PageFactory {
         console.debug(`Entity resolution: "${name}" matched existing page "${result.path}"`);
         // Append the new name as an alias to the existing page to prevent future duplicates
         await this.appendAliases(result.path, [name]);
-        return result.path;
+        return { path: result.path };
       }
     } catch (error) {
       console.debug(`Entity resolution for "${name}" failed, using slug path:`, error);
     }
 
-    return slugPath;
+    return { path: slugPath };
   }
 
   async buildPagesListForPrompt(includePaths: string[] = []): Promise<string> {
@@ -231,7 +248,7 @@ export class PageFactory {
     _analysis: SourceAnalysis,
     sourceFile: TFile | { path: string; basename: string },
     extraPagePaths: string[] = []
-  ): Promise<string | null> {
+  ): Promise<PageCreationResult> {
     return this.createOrUpdatePage(entity, 'entity', sourceFile, extraPagePaths);
   }
 
@@ -240,7 +257,7 @@ export class PageFactory {
     _analysis: SourceAnalysis,
     sourceFile: TFile | { path: string; basename: string },
     extraPagePaths: string[] = []
-  ): Promise<string | null> {
+  ): Promise<PageCreationResult> {
     return this.createOrUpdatePage(concept, 'concept', sourceFile, extraPagePaths);
   }
 
@@ -251,37 +268,42 @@ export class PageFactory {
     pageType: 'entity' | 'concept',
     sourceFile: TFile | { path: string; basename: string },
     extraPagePaths: string[] = []
-  ): Promise<string | null> {
+  ): Promise<PageCreationResult> {
     if (!info.name || info.name.trim().length === 0) {
       console.warn(`${pageType} name is empty, skipping creation`);
-      return null;
+      return { path: null };
     }
 
     console.debug(`=== Creating/Updating ${pageType} page ===`);
     console.debug('name:', info.name);
     console.debug('type:', info.type);
 
-    const path = await this.resolvePagePath(info.name, pageType, info.summary);
-    if (path === null) {
-      console.debug(`Skipping ${pageType} "${info.name}": cross-type duplicate exists`);
-      return null;
+    const result = await this.resolvePagePath(info.name, pageType, info.summary);
+    if (result.path === null) {
+      if (result.collision) {
+        console.debug(`Skipping ${pageType} "${info.name}": cross-type duplicate exists in ${result.collision.targetType}`);
+      }
+      return result;
     }
-    console.debug('Resolved path:', path);
+    console.debug('Resolved path:', result.path);
 
-    const existingContent = await this.ctx.tryReadFile(path);
+    const existingContent = await this.ctx.tryReadFile(result.path);
 
     if (!existingContent) {
-      return this.createNewPage(info, pageType, sourceFile, extraPagePaths, path);
+      const createdPath = await this.createNewPage(info, pageType, sourceFile, extraPagePaths, result.path);
+      return { path: createdPath };
     }
 
     const isReviewed = parseFrontmatter(existingContent)?.reviewed === true;
 
     if (isReviewed) {
-      console.debug(`${pageType} page has reviewed: true, using minimal append mode:`, path);
-      return this.appendToReviewedPage(info, sourceFile, existingContent, path);
+      console.debug(`${pageType} page has reviewed: true, using minimal append mode:`, result.path);
+      const updatedPath = await this.appendToReviewedPage(info, sourceFile, existingContent, result.path);
+      return { path: updatedPath };
     }
 
-    return this.mergePage(info, pageType, sourceFile, existingContent, extraPagePaths, path);
+    const mergedPath = await this.mergePage(info, pageType, sourceFile, existingContent, extraPagePaths, result.path);
+    return { path: mergedPath };
   }
 
   private async createNewPage(

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -237,6 +237,7 @@ export class WikiEngine {
     this.onProgress?.(`Analyzing: ${file.basename}`);
 
     const failedItems: Array<{ type: 'entity' | 'concept'; name: string; reason: string }> = [];
+    const collisions: Array<{ name: string; sourceType: 'entity' | 'concept'; targetType: 'entity' | 'concept'; targetPath: string }> = [];
     let analysis: SourceAnalysis | null = null;
 
     try {
@@ -316,11 +317,15 @@ export class WikiEngine {
             if (task.type === 'entity') {
               const entity = analysis!.entities[task.index];
               try {
-                const entityPage = await this.pageFactory.createOrUpdateEntityPage(entity, analysis!, file);
-                if (entityPage) {
-                  analysis!.created_pages.push(entityPage);
+                const entityResult = await this.pageFactory.createOrUpdateEntityPage(entity, analysis!, file);
+                if (entityResult.path) {
+                  analysis!.created_pages.push(entityResult.path);
                 }
-                return { success: true as const, name: entity.name, type: 'entity' as const };
+                if (entityResult.collision) {
+                  collisions.push(entityResult.collision);
+                  console.debug(`Entity "${entity.name}" → collision with ${entityResult.collision.targetType}`);
+                }
+                return { success: true as const, name: entity.name, type: 'entity' as const, collision: entityResult.collision };
               } catch (error) {
                 const reason = error instanceof Error ? error.message : String(error);
                 console.error(`Entity "${entity.name}" failed:`, reason);
@@ -329,11 +334,14 @@ export class WikiEngine {
                 // Retry once
                 try {
                   await this.apiDelay(2000);
-                  const retryPage = await this.pageFactory.createOrUpdateEntityPage(entity, analysis!, file);
-                  if (retryPage) {
-                    analysis!.created_pages.push(retryPage);
+                  const retryResult = await this.pageFactory.createOrUpdateEntityPage(entity, analysis!, file);
+                  if (retryResult.path) {
+                    analysis!.created_pages.push(retryResult.path);
                     console.debug(`Entity "${entity.name}" recovered on retry`);
                     failedItems.pop();
+                  }
+                  if (retryResult.collision) {
+                    collisions.push(retryResult.collision);
                   }
                 } catch {
                   console.error(`Entity "${entity.name}" retry also failed`);
@@ -343,11 +351,15 @@ export class WikiEngine {
             } else {
               const concept = analysis!.concepts[task.index];
               try {
-                const conceptPage = await this.pageFactory.createOrUpdateConceptPage(concept, analysis!, file);
-                if (conceptPage) {
-                  analysis!.created_pages.push(conceptPage);
+                const conceptResult = await this.pageFactory.createOrUpdateConceptPage(concept, analysis!, file);
+                if (conceptResult.path) {
+                  analysis!.created_pages.push(conceptResult.path);
                 }
-                return { success: true as const, name: concept.name, type: 'concept' as const };
+                if (conceptResult.collision) {
+                  collisions.push(conceptResult.collision);
+                  console.debug(`Concept "${concept.name}" → collision with ${conceptResult.collision.targetType}`);
+                }
+                return { success: true as const, name: concept.name, type: 'concept' as const, collision: conceptResult.collision };
               } catch (error) {
                 const reason = error instanceof Error ? error.message : String(error);
                 console.error(`Concept "${concept.name}" failed:`, reason);
@@ -356,11 +368,14 @@ export class WikiEngine {
                 // Retry once
                 try {
                   await this.apiDelay(2000);
-                  const retryPage = await this.pageFactory.createOrUpdateConceptPage(concept, analysis!, file);
-                  if (retryPage) {
-                    analysis!.created_pages.push(retryPage);
+                  const retryResult = await this.pageFactory.createOrUpdateConceptPage(concept, analysis!, file);
+                  if (retryResult.path) {
+                    analysis!.created_pages.push(retryResult.path);
                     console.debug(`Concept "${concept.name}" recovered on retry`);
                     failedItems.pop();
+                  }
+                  if (retryResult.collision) {
+                    collisions.push(retryResult.collision);
                   }
                 } catch {
                   console.error(`Concept "${concept.name}" retry also failed`);
@@ -511,7 +526,7 @@ export class WikiEngine {
       const totalTime = Date.now() - totalStartTime;
 
       console.debug('=== Ingestion complete ===');
-      console.debug(`Ingestion complete [${modeLabel}]: Created ${created} pages (${entitiesCreated} entities + ${conceptsCreated} concepts), Updated ${updated} pages`);
+      console.debug(`Ingestion complete [${modeLabel}]: Created ${created} pages (${entitiesCreated} entities + ${conceptsCreated} concepts), Updated ${updated} pages, ${collisions.length} cross-type collisions`);
       console.debug(`[Total time] ${totalTime}ms (${Math.round(totalTime/1000)}s)`);
       console.debug('[Phase breakdown]:');
       console.debug(`  - Source analysis: ${analysisTime}ms`);
@@ -521,6 +536,14 @@ export class WikiEngine {
       console.debug(`  - Contradiction recording: ${contradictionTime}ms`);
       console.debug(`  - Index & log: ${indexTime}ms`);
 
+      // Show collision notice if any occurred
+      if (collisions.length > 0) {
+        const t = TEXTS[this.settings.language] || TEXTS.en;
+        const collisionNotice = (t as unknown as Record<string, string>).crossTypeCollisionNotice ||
+          `${collisions.length} items merged as cross-type aliases (entity ↔ concept duplicates prevented)`;
+        new Notice(collisionNotice.replace('{count}', String(collisions.length)), 5000);
+      }
+
       this.onDone?.({
         sourceFile: file.path,
         createdPages: analysis.created_pages,
@@ -528,6 +551,7 @@ export class WikiEngine {
         entitiesCreated,
         conceptsCreated,
         failedItems,
+        collisions,
         contradictionsFound: analysis.contradictions.length,
         success: true,
         elapsedSeconds: Math.round(totalTime / 1000)
@@ -548,6 +572,7 @@ export class WikiEngine {
           entitiesCreated: createdPages.filter(p => p.includes('/entities/')).length,
           conceptsCreated: createdPages.filter(p => p.includes('/concepts/')).length,
           failedItems,
+          collisions,
           contradictionsFound: analysis?.contradictions?.length || 0,
           success: false,
           cancelled: true,
@@ -568,6 +593,7 @@ export class WikiEngine {
         entitiesCreated: createdPages.filter(p => p.includes('/entities/')).length,
         conceptsCreated: createdPages.filter(p => p.includes('/concepts/')).length,
         failedItems,
+        collisions,
         contradictionsFound: analysis?.contradictions?.length || 0,
         success: false,
         errorMessage: errorMsg,


### PR DESCRIPTION
## Summary
This PR complements PR #54's cross-type duplicate prevention with user-facing feedback.

**Key Changes:**
- Add `PageCreationResult` type with optional `collision` info
- Modify `resolvePagePath`/`createOrUpdatePage` to return collision details
- Add `collisions` field to `IngestReport` (backward compatible)
- Display Notice when collisions occur during ingestion
- Add 8-language i18n for `crossTypeCollisionNotice`

**User Experience:**
When a cross-type collision is detected (e.g., "Deep Learning" extracted as entity but already exists as concept), users now see:
- Console debug: `Entity "Deep Learning" → collision with concept`
- Notice: `"2 items merged as cross-type aliases (entity ↔ concept duplicates prevented)"`
- Log: `"Created 5 pages, 2 cross-type collisions"`

## Test plan
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 165 tests pass
- [x] `npx tsc --noEmit` — 0 errors  
- [x] `pnpm build` — clean exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)