### PR TITLE
fix(ingest): don't abort source analysis when a batch returns only entities or only concepts

### DIFF
--- a/src/wiki/prompts/ingestion.ts
+++ b/src/wiki/prompts/ingestion.ts
@@ -12,7 +12,7 @@ export const INGESTION_PROMPTS = {
 {{granularity_instruction}}
 
 **Task Requirements:**
-0. Output the source file title (source_title) and a 100-200 word source summary (summary). Only output these two fields in the first round
+0. Output the source file title (source_title) and a 100-200 word source summary (summary). These two fields appear in the FIRST round ONLY (omit them in later rounds). This does NOT mean the first round contains only these two fields: you MUST still output the entities and concepts arrays defined below, using [] when a category has no items.
 1. Extract entities and concepts that DESERVE standalone wiki pages — items another note could meaningfully link to, and that remain understandable independent of this source. Apply the wiki-link test before extracting: "Would a different note in this knowledge base link to [[this]]? Would someone search the wiki for this name?" If the answer is no, skip it. Bibliographic references (author citations like "Smith et al. 2022", study/trial names used as evidence pointers, journal article titles) are evidence containers — extract their FINDINGS as concepts instead, not the citation as an entity. Judge by wiki-graph value, not by prominence in the text
 2. Output at most {{batch_size}} items (entities + concepts total) this round
 3. Write a detailed, informative summary for each item (target 4-6 sentences). Include concrete information: what the entity/concept is, its role/significance in the source, key factual details, and how it relates to other items. Provide enough substance that the summary alone can seed a quality Wiki page

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -154,13 +154,21 @@ export class SourceAnalyzer {
         }
 
         if (isFirstBatch) {
-          if (!analysisData.entities || !analysisData.concepts) {
-            console.error('❌ Round 1 missing required fields (entities/concepts):', {
+          // A first batch is only unusable when BOTH arrays are absent. A response with
+          // just one (e.g. a glossary that yields only entities) is valid: the rest of this
+          // method already tolerates a missing array via `(... || [])`, and the final guard
+          // below only aborts when nothing was extracted at all. The old `||` aborted the
+          // entire ingest whenever a model omitted an (often empty) array.
+          if (!analysisData.entities && !analysisData.concepts) {
+            console.error('❌ Round 1 missing BOTH entities and concepts (unusable response):', {
               entities: !!analysisData.entities,
               concepts: !!analysisData.concepts
             });
             return null;
           }
+          // A model may omit an empty array entirely instead of returning [].
+          if (!Array.isArray(analysisData.entities)) analysisData.entities = [];
+          if (!Array.isArray(analysisData.concepts)) analysisData.concepts = [];
           if (!analysisData.source_title) {
             console.debug('Round 1 missing source_title, falling back to filename:', file.basename);
           }


### PR DESCRIPTION
## Problem

Ingesting a source aborts with **"Source analysis failed for …"** whenever the first analysis batch returns one of `entities` / `concepts` but not the other.

`SourceAnalyzer.analyzeSource` validates the first batch with:

```ts
if (!analysisData.entities || !analysisData.concepts) {
  console.error('❌ Round 1 missing required fields (entities/concepts):', …);
  return null;          // → ingestSource() throws "Source analysis failed"
}
```

`analysisData` is typed `Partial<SourceAnalysis>`, so either field may legitimately be absent. With `||`, a response that has a populated `entities` array but no `concepts` key (or vice-versa) fails the **entire** ingest — even though the method is otherwise tolerant:

- the rest of `analyzeSource` already handles a missing array via `(analysisData.entities || [])` / `(analysisData.concepts || [])`;
- a missing `source_title` only logs a debug note and falls back to the filename;
- the **final** guard only aborts when nothing was extracted at all: `if (!firstBatchData && allEntities.length === 0 && allConcepts.length === 0) return null;`

So the first-batch gate is stricter than — and inconsistent with — the function's own design. It hits hardest on:

- **glossary / entity-heavy (or concept-heavy) sources**, where one category is legitimately empty;
- **smaller / local models** (e.g. via Ollama) that omit an empty array entirely instead of emitting `[]`.

(Because `!![] === true`, the gate only fires when the key is **absent/null**, confirming it is an omission rather than an empty array.)

## Repro

1. Provider = a local OpenAI-compatible model (e.g. Ollama).
2. Ingest a glossary-style source (mostly terms/definitions).
3. The model returns `{ source_title, summary, entities: [...] }` with no `concepts` key.
4. Console: `❌ Round 1 missing required fields (entities/concepts): {entities: true, concepts: false}` → `Source analysis failed`.

## Fix

**`src/wiki/source-analyzer.ts`** — abort only when **both** arrays are absent (`&&`), then coerce any non-array `entities` / `concepts` to `[]` so the downstream loop and the returned `SourceAnalysis` are always well-formed. This aligns the early gate with the lenient final guard. As a bonus, coercion prevents a hard `TypeError` if a model returns a non-array truthy value (the old code would pass the `||` gate and then throw on the later `.filter(...)`).

**`src/wiki/prompts/ingestion.ts`** — task item 0 (*"Only output these two fields in the first round"*) is ambiguous and can nudge smaller models into emitting only `source_title`/`summary` and dropping the arrays. Reworded so the two fields are clearly first-round-only **and** both arrays must still be output (`[]` when empty). This is defense-in-depth; the code change is the actual fix.

## Verification

- **Gate logic** (isolated): `entities`-only and `concepts`-only inputs now proceed with the empty side coerced to `[]`; a response with neither still aborts; a previously-crashing non-array value (`entities: true`) no longer throws.
- **End-to-end**: re-ingesting the failing glossary completes successfully and creates pages instead of throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
