### PR TITLE
fix: alias self-pointing dedup + blog links + Three-No framework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,21 +127,77 @@ src/
 
 ## 🛡️ Three-No Principle
 
-Every change must satisfy all three before being considered complete. **Automated checks alone are not sufficient** — each item requires explicit manual verification against the modified code.
+Every change must satisfy all three before being considered complete.
+**Automated gates catch syntax/type/test errors; manual review catches logic
+and architectural errors that no linter can see.**
 
-1. **No Side Effects — required manual review**: Changes must not affect behavior outside their intended scope. Refactored code must produce identical output. New features must not alter existing workflows.
-   - **Manual check**: Read every call-site of the modified function. Trace data flow through all consumers. Verify no other module depends on the previous behavior. Check that error propagation paths remain intact.
-2. **No Breaking Changes — required manual review**: No API signature changes without call-site updates. No config format changes. No file format changes. Existing users must not need to reconfigure.
-   - **Manual check**: Compare old and new function signatures. Check settings schema for added/removed fields. Verify saved `data.json` from previous versions still loads correctly.
-3. **No Test Errors or Warnings — automated gates**: `pnpm lint` must produce 0 errors and 0 warnings. `pnpm test` must pass all tests (0 failures). `npx tsc --noEmit` must produce 0 errors. `pnpm build` must exit cleanly.
+### 1. No Side Effects — required structured review
 
-Verification gates:
+**Goal**: The change does not alter behavior outside its intended scope.
+
+#### 1a. Call-site Audit
+Run `grep -rn "<functionName>" src/` to list every call-site. For each:
+- [ ] **Arguments**: check if any caller depends on old return value / side effect
+- [ ] **Return value**: check if any caller would break with new return shape
+- [ ] **Error handling**: check if try/catch or `.catch()` paths still make sense
+
+#### 1b. Data Flow Trace
+For each modified function, trace:
+- [ ] **Inputs**: Where does each parameter value originate? (user input / setting / file / LLM / computed)
+- [ ] **Outputs**: Where does each return value / mutated state go? (file write / UI / downstream function / cache)
+- [ ] **Side effects**: Does the function mutate external state? (file system, Obsidian API, global vars, DOM)
+- [ ] **IO points**: Mark every `await this.ctx.*`, `app.*`, `document.*`, `localStorage.*`
+
+#### 1c. State Mutation Analysis
+- [ ] If the function is async: can it run concurrently with itself or another function touching the same state?
+- [ ] If the function writes files: does it overwrite or append? Is the path deterministic?
+- [ ] If the function reads settings: does it handle missing/new fields gracefully?
+
+#### 1d. Error Propagation Check
+- [ ] New error paths: are they caught by all callers?
+- [ ] Changed error types: do existing catch blocks still match?
+- [ ] Silent failures: are there any paths that swallow errors without logging?
+
+**Deliverable**: A 3-5 sentence side-effect assessment, e.g.:
+> "Modified `resolvePagePath` is called from 2 private methods in PageFactory.
+> The new `collision` return field is consumed by `createOrUpdatePage` and
+> `IngestReportModal` only. No other module touches this path. The function
+> still writes aliases via `appendAliases` (same side effect as before); no
+> new IO introduced."
+
+### 2. No Breaking Changes — required structured review
+
+**Goal**: Existing users do not need to reconfigure or migrate data.
+
+| Dimension | Check | Method | Pass Criteria |
+|-----------|-------|--------|---------------|
+| **API Signature** | Function params / return type changed? | `git diff` + `grep` | All call-sites updated; no new required params without defaults |
+| **Settings Schema** | `data.json` fields added/removed? | Check `types.ts` + `settings.ts` | New fields have defaults in constructor; removed fields are gracefully ignored |
+| **File Format** | Frontmatter / output / index format changed? | Check generation templates | Old files load without error; new format is backward-compatible |
+| **Default Behavior** | Any default value changed? | Check constructor / config init | Old behavior is preserved unless explicitly opted in |
+| **Command/Setting IDs** | Any command palette ID or setting key renamed? | `grep` for IDs/keys | IDs unchanged; if changed, old IDs still map |
+| **Obsidian API** | Minimum Obsidian version requirement changed? | `manifest.json` | `minAppVersion` >= current; no new Obsidian-exclusive APIs |
+
+**Deliverable**: A breaking-change verdict: "None detected" or a specific migration plan.
+
+### 3. No Test Errors or Warnings — automated gates
+
+```bash
+pnpm lint          # ESLint: must produce 0 errors, 0 warnings
+pnpm test          # Vitest: all pass, 0 failures
+npx tsc --noEmit   # TypeScript: 0 errors
+pnpm build         # esbuild: clean exit
 ```
-pnpm lint          # 0 errors, 0 warnings
-pnpm test          # all pass, 0 failures
-npx tsc --noEmit   # 0 errors
-pnpm build         # clean exit
-```
+
+If any gate fails: fix the root cause, do NOT add `@ts-ignore` or `eslint-disable`
+to silence it. Re-run all four gates after each fix.
+
+### ⚠️ Anti-patterns that bypass these checks
+
+- "The tests pass, so it's fine" → Tests only cover what you thought to test
+- "It's just a one-line change" → One-line changes are the most dangerous
+- "I'll add tests later" → Tests must accompany the change, not follow it
+- "The PR review will catch it" → The reviewer has less context than you
 
 ## ⚠️ Git Safety Protocol
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [English](README.md) | [中文文档](docs/README_CN.md) | [日本語](docs/README_JA.md) | [한국어](docs/README_KO.md) | [Deutsch](docs/README_DE.md) | [Français](docs/README_FR.md) | [Español](docs/README_ES.md) | [Português](docs/README_PT.md)
 
-[Official Site](https://llmwiki.greenerai.top/) | [Feedback & Discussion](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 Explore Repo with DeepWiki](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
+[Official Site](https://llmwiki.greenerai.top/) | [Blog](https://llmwiki.greenerai.top/blog/) | [Feedback & Discussion](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 Explore Repo with DeepWiki](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 ---
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -10,7 +10,7 @@
 
 [English](../README.md) | [中文文档](README_CN.md) | [日本語](README_JA.md) | [한국어](README_KO.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | [Español](README_ES.md) | [Português](README_PT.md)
 
-[官网](https://llmwiki.greenerai.top/) | [反馈讨论](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 用 DeepWiki 读懂代码库](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
+[官网](https://llmwiki.greenerai.top/) | [博客](https://llmwiki.greenerai.top/zh/blog/) | [反馈讨论](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 用 DeepWiki 读懂代码库](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 ---
 

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -10,7 +10,7 @@
 
 [English](../README.md) | [中文文档](README_CN.md) | [日本語](README_JA.md) | [한국어](README_KO.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | [Español](README_ES.md) | [Português](README_PT.md)
 
-[Offizielle Website](https://llmwiki.greenerai.top/) | [Feedback & Diskussion](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 Codebasis mit DeepWiki erkunden](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
+[Offizielle Website](https://llmwiki.greenerai.top/) | [Blog](https://llmwiki.greenerai.top/blog/) | [Feedback & Diskussion](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 Codebasis mit DeepWiki erkunden](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 ---
 

--- a/docs/README_ES.md
+++ b/docs/README_ES.md
@@ -10,7 +10,7 @@
 
 [English](../README.md) | [中文文档](README_CN.md) | [日本語](README_JA.md) | [한국어](README_KO.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | [Español](README_ES.md) | [Português](README_PT.md)
 
-[Sitio oficial](https://llmwiki.greenerai.top/) | [Comentarios y debate](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 Explorar código con DeepWiki](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
+[Sitio oficial](https://llmwiki.greenerai.top/) | [Blog](https://llmwiki.greenerai.top/blog/) | [Comentarios y debate](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 Explorar código con DeepWiki](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 ---
 

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -10,7 +10,7 @@
 
 [English](../README.md) | [中文文档](README_CN.md) | [日本語](README_JA.md) | [한국어](README_KO.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | [Español](README_ES.md) | [Português](README_PT.md)
 
-[Site officiel](https://llmwiki.greenerai.top/) | [Retour d'expérience](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 Explorer le code avec DeepWiki](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
+[Site officiel](https://llmwiki.greenerai.top/) | [Blog](https://llmwiki.greenerai.top/blog/) | [Retour d'expérience](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 Explorer le code avec DeepWiki](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 ---
 

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -10,7 +10,7 @@
 
 [English](../README.md) | [中文文档](README_CN.md) | [日本語](README_JA.md) | [한국어](README_KO.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | [Español](README_ES.md) | [Português](README_PT.md)
 
-[公式サイト](https://llmwiki.greenerai.top/) | [フィードバック](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 DeepWiki でコードベースを探索](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
+[公式サイト](https://llmwiki.greenerai.top/) | [ブログ](https://llmwiki.greenerai.top/blog/) | [フィードバック](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 DeepWiki でコードベースを探索](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 ---
 

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -10,7 +10,7 @@
 
 [English](../README.md) | [中文文档](README_CN.md) | [日本語](README_JA.md) | [한국어](README_KO.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | [Español](README_ES.md) | [Português](README_PT.md)
 
-[공식 사이트](https://llmwiki.greenerai.top/) | [피드백 토론](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 DeepWiki로 코드베이스 탐색](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
+[공식 사이트](https://llmwiki.greenerai.top/) | [블로그](https://llmwiki.greenerai.top/blog/) | [피드백 토론](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 DeepWiki로 코드베이스 탐색](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 ---
 

--- a/docs/README_PT.md
+++ b/docs/README_PT.md
@@ -10,7 +10,7 @@
 
 [English](../README.md) | [中文文档](README_CN.md) | [日本語](README_JA.md) | [한국어](README_KO.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | [Español](README_ES.md) | [Português](README_PT.md)
 
-[Site oficial](https://llmwiki.greenerai.top/) | [Feedback e discussão](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 Explorar código com DeepWiki](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
+[Site oficial](https://llmwiki.greenerai.top/) | [Blog](https://llmwiki.greenerai.top/blog/) | [Feedback e discussão](https://github.com/green-dalii/obsidian-llm-wiki/discussions) | [🤖 Explorar código com DeepWiki](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 ---
 

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { slugify, computeSlug, parseFrontmatter, detectRateLimitFailures, formatRateLimitNotice, cleanMarkdownResponse, enforceFrontmatterConstraints, parseJsonResponse, mergeFrontmatter, preserveFrontmatterReviewTag, extractBody, getText } from '../utils';
+import { slugify, computeSlug, parseFrontmatter, detectRateLimitFailures, formatRateLimitNotice, cleanMarkdownResponse, enforceFrontmatterConstraints, parseJsonResponse, mergeFrontmatter, preserveFrontmatterReviewTag, extractBody, getText, filterRedundantAliases } from '../utils';
 import { getGranularityInstruction, getGranularityFixLimits } from '../wiki/system-prompts';
 import { LLMWikiSettings } from '../types';
 
@@ -766,5 +766,44 @@ describe('getText', () => {
   it('handles non-existent replacement placeholders gracefully', () => {
     const result = getText('en', 'ingestionCancelled', { nonexistent: 'foo' });
     expect(result).toBe('Ingestion cancelled');
+  });
+});
+
+describe('filterRedundantAliases', () => {
+  it('drops an alias identical to the page filename (case-insensitive)', () => {
+    const result = filterRedundantAliases('wiki/entities/vigilanz.md', ['Vigilanz']);
+    expect(result).toEqual([]);
+  });
+
+  it('keeps a genuine alias that differs from the filename', () => {
+    const result = filterRedundantAliases('wiki/entities/vigilanz.md', ['监测']);
+    expect(result).toEqual(['监测']);
+  });
+
+  it('drops self-pointing alias but keeps distinct ones in the same batch', () => {
+    const result = filterRedundantAliases('wiki/entities/openai.md', ['OpenAI', 'OAI']);
+    expect(result).toEqual(['OAI']);
+  });
+
+  it('keeps a space-variant alias because Obsidian does not collapse spaces to dashes', () => {
+    // File is deep-learning.md; [[Deep Learning]] would NOT auto-resolve to it,
+    // so "Deep Learning" is a useful alias and must be kept.
+    const result = filterRedundantAliases('wiki/concepts/deep-learning.md', ['Deep Learning']);
+    expect(result).toEqual(['Deep Learning']);
+  });
+
+  it('removes duplicate aliases within the batch (case-insensitive)', () => {
+    const result = filterRedundantAliases('wiki/entities/foo.md', ['GPT', 'gpt']);
+    expect(result).toEqual(['GPT']);
+  });
+
+  it('skips empty or whitespace-only aliases', () => {
+    const result = filterRedundantAliases('wiki/entities/openai.md', ['', '   ', 'OpenAI Inc']);
+    expect(result).toEqual(['OpenAI Inc']);
+  });
+
+  it('handles paths without a folder prefix', () => {
+    const result = filterRedundantAliases('vigilanz.md', ['Vigilanz', 'Surveillance']);
+    expect(result).toEqual(['Surveillance']);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,6 +65,33 @@ export function computeSlug(text: string): string {
   return finalSlug;
 }
 
+// Filter out aliases that are redundant against a page's own filename.
+// Obsidian resolves `[[X]]` to a file whose basename equals X (case-insensitive),
+// so an alias that already equals the filename is a self-pointing no-op that only
+// clutters frontmatter. This commonly happens on cross-type collisions where the
+// colliding name is identical to the existing page's name (e.g. adding "Vigilanz"
+// to vigilanz.md). Comparison is exact case-insensitive basename match — NOT slug
+// based — because Obsidian does not collapse spaces/symbols when resolving links,
+// so a space-variant like "Deep Learning" on deep-learning.md IS a useful alias
+// and must be kept.
+// Pure function (no IO) so the dedup rule can be unit-tested in isolation.
+export function filterRedundantAliases(
+  pagePath: string,
+  candidateAliases: string[]
+): string[] {
+  const fileName = pagePath.split('/').pop() || '';
+  const fileKey = fileName.replace(/\.md$/i, '').trim().toLowerCase();
+  const seen = new Set<string>();
+  return candidateAliases.filter(alias => {
+    if (!alias || alias.trim().length === 0) return false;
+    const key = alias.trim().toLowerCase();
+    if (key === fileKey) return false; // already resolves to this file — redundant
+    if (seen.has(key)) return false; // duplicate within the batch (case-insensitive)
+    seen.add(key);
+    return true;
+  });
+}
+
 export async function parseJsonResponse(
   response: string,
   repairFn?: (malformedJson: string) => Promise<string>

--- a/src/wiki/page-factory.ts
+++ b/src/wiki/page-factory.ts
@@ -19,6 +19,7 @@ import {
   parseJsonResponse,
   enforceFrontmatterConstraints,
   truncateMentions,
+  filterRedundantAliases,
 } from '../utils';
 import { applySectionLabels } from './system-prompts';
 import { getExistingWikiPages } from './lint-fixes';
@@ -42,9 +43,15 @@ export class PageFactory {
     const content = await this.ctx.tryReadFile(pagePath);
     if (!content) return;
 
+    // Drop aliases that already equal the page's filename (case-insensitive),
+    // e.g. adding "Vigilanz" to vigilanz.md. Common on cross-type collisions
+    // where the colliding name is identical to the existing page's name.
+    const candidates = filterRedundantAliases(pagePath, newAliases);
+    if (candidates.length === 0) return;
+
     const fm = parseFrontmatter(content);
     const existingAliases = Array.isArray(fm?.aliases) ? fm.aliases : [];
-    const toAdd = newAliases.filter(a => !existingAliases.includes(a));
+    const toAdd = candidates.filter(a => !existingAliases.includes(a));
     if (toAdd.length === 0) return;
 
     const merged = [...existingAliases, ...toAdd];


### PR DESCRIPTION
## Summary
Three independent improvements bundled:

1. **fix(page-factory): skip self-pointing aliases on cross-type collisions**
   - Add `filterRedundantAliases` pure function that drops aliases equal to the page's own filename (case-insensitive)
   - Prevents redundant self-pointing aliases like adding "Vigilanz" to `vigilanz.md`
   - Uses exact basename match (not slug-based) to preserve useful space-variants like "Deep Learning" on `deep-learning.md`
   - +7 unit tests (180 total)

2. **docs: add official blog link to all 8 READMEs**
   - CN points to `/zh/blog/`, others to `/blog/`

3. **docs: restructure Three-No Principle into actionable evaluation framework**
   - Replace abstract descriptions with structured review procedures
   - Add breaking-change assessment matrix and deliverable templates

## Test plan
- [x] `pnpm lint` — 0 errors, 0 warnings
- [x] `pnpm test` — 180 passed (was 173)
- [x] `npx tsc --noEmit` — 0 errors
- [x] `pnpm build` — clean exit

## Side-effect assessment
`filterRedundantAliases` is pure (no IO). `appendAliases` is private; all 4 call-sites pass `[name]`. Non-redundant path behavior is identical to old code. No new external state mutation.

## Breaking-change assessment
None detected. Pure additive change; no API signature, settings schema, file format, or default behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)