### PR TITLE
refactor: normalizeBatchResponse + aliases seeding + multi-round context

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -807,3 +807,109 @@ describe('filterRedundantAliases', () => {
     expect(result).toEqual(['Surveillance']);
   });
 });
+
+// ── normalizeBatchResponse is in source-analyzer.ts ──────────────
+
+import {
+  normalizeBatchResponse,
+} from '../wiki/source-analyzer';
+
+describe('normalizeBatchResponse', () => {
+  it('returns unusable for null input', () => {
+    const { validity } = normalizeBatchResponse(null);
+    expect(validity).toBe('unusable');
+  });
+
+  it('returns unusable when both entities and concepts keys are absent', () => {
+    const { validity } = normalizeBatchResponse({});
+    expect(validity).toBe('unusable');
+  });
+
+  it('returns empty when both arrays are explicitly empty', () => {
+    const { validity } = normalizeBatchResponse({ entities: [], concepts: [] });
+    expect(validity).toBe('empty');
+  });
+
+  it('returns valid when only entities are present (glossary case)', () => {
+    const raw = {
+      entities: [{ name: 'Foo', type: 'other' as const, summary: 'S', mentions_in_source: [] }],
+      // concepts key absent — should not cause unusable
+    };
+    const { validity, data } = normalizeBatchResponse(raw);
+    expect(validity).toBe('valid');
+    expect(data.entities).toHaveLength(1);
+    expect(data.concepts).toHaveLength(0);
+  });
+
+  it('returns valid when only concepts are present', () => {
+    const raw = {
+      concepts: [{ name: 'Bar', type: 'theory' as const, summary: 'S', related_concepts: [], mentions_in_source: [] }],
+    };
+    const { validity, data } = normalizeBatchResponse(raw);
+    expect(validity).toBe('valid');
+    expect(data.entities).toHaveLength(0);
+    expect(data.concepts).toHaveLength(1);
+  });
+
+  it('coerces non-array truthy values to empty (e.g. entities: true)', () => {
+    const raw: Record<string, unknown> = {
+      entities: true,
+      concepts: [{ name: 'Bar', type: 'theory' as const, summary: 'S', related_concepts: [], mentions_in_source: [] }],
+    };
+    const { validity, data } = normalizeBatchResponse(raw);
+    expect(validity).toBe('valid');
+    expect(data.entities).toEqual([]);
+    expect(data.concepts).toHaveLength(1);
+  });
+
+  it('coerces null entities to empty', () => {
+    const raw: Record<string, unknown> = {
+      entities: null,
+      concepts: [{ name: 'Bar', type: 'theory' as const, summary: 'S', related_concepts: [], mentions_in_source: [] }],
+    };
+    const { validity, data } = normalizeBatchResponse(raw);
+    expect(validity).toBe('valid');
+    expect(data.entities).toEqual([]);
+  });
+
+  it('filters items with empty name', () => {
+    const raw = {
+      entities: [
+        { name: '', type: 'other' as const, summary: 'S', mentions_in_source: [] },
+        { name: 'Real', type: 'other' as const, summary: 'S', mentions_in_source: [] },
+      ],
+    };
+    const { validity, data } = normalizeBatchResponse(raw);
+    expect(validity).toBe('valid');
+    expect(data.entities).toHaveLength(1);
+    expect(data.entities[0].name).toBe('Real');
+  });
+
+  it('extracts sourceTitle and summary', () => {
+    const raw = {
+      entities: [{ name: 'Foo', type: 'other' as const, summary: 'S', mentions_in_source: [] }],
+      source_title: 'Test Title',
+      summary: 'Test summary body.',
+    };
+    const { data } = normalizeBatchResponse(raw);
+    expect(data.sourceTitle).toBe('Test Title');
+    expect(data.summary).toBe('Test summary body.');
+  });
+
+  it('strips wiki-link formatting from relatedPages', () => {
+    const raw = {
+      entities: [{ name: 'Foo', type: 'other' as const, summary: 'S', mentions_in_source: [] }],
+      related_pages: ['[[entities/Bar]]', '[[concepts/Baz|Baz Title]]'],
+    };
+    const { data } = normalizeBatchResponse(raw);
+    // [[path]] stays as-is (no pipe separator); [[path|name]] strips to display name
+    expect(data.relatedPages).toEqual(['entities/Bar', 'Baz Title']);
+  });
+
+  it('validity is unusable when both keys absent but overrides for empty arrays', () => {
+    // Absent keys → unusable
+    expect(normalizeBatchResponse({}).validity).toBe('unusable');
+    // Explicit [] → empty (can distinguish from "LLM didn't try")
+    expect(normalizeBatchResponse({ entities: [], concepts: [] }).validity).toBe('empty');
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface SourceAnalysis {
 export interface EntityInfo {
   name: string;
   type: 'person' | 'organization' | 'project' | 'product' | 'event' | 'location' | 'other';
+  aliases?: string[];  // Pre-generated aliases from extraction (seeds for page generation)
   summary: string;
   mentions_in_source: string[];
   related_entities?: string[];
@@ -27,6 +28,7 @@ export interface EntityInfo {
 export interface ConceptInfo {
   name: string;
   type: 'theory' | 'method' | 'technology' | 'term' | 'other';
+  aliases?: string[];  // Pre-generated aliases from extraction (seeds for page generation)
   summary: string;
   mentions_in_source: string[];
   related_concepts: string[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -899,3 +899,13 @@ export function matchExtractedToExisting(
   }
   return [...matched];
 }
+
+// Coerce a potentially non-array value to an array.
+// Used for LLM output normalization where models may omit empty arrays
+// or return non-array truthy values (e.g. entities: true). Pure function.
+export function coerceToArray<T>(value: unknown): T[] {
+  if (Array.isArray(value)) {
+    return value as T[];
+  }
+  return [];
+}

--- a/src/wiki/page-factory.ts
+++ b/src/wiki/page-factory.ts
@@ -348,6 +348,8 @@ export class PageFactory {
       .replace('{{concept_type}}', info.type)
       .replace('{{entity_summary}}', info.summary)
       .replace('{{concept_summary}}', info.summary)
+      .replace('{{extraction_aliases}}', info.aliases?.length
+        ? `[${info.aliases.join(', ')}]` : 'None')
       .replace('{{mentions}}', truncateMentions(info.mentions_in_source) || 'No specific mentions')
       .replace('{{related_entities}}', info.related_entities?.join(', ') || 'No related entities')
       .replace('{{related_concepts}}', info.related_concepts?.join(', ') || 'No related concepts')

--- a/src/wiki/prompts/generation.ts
+++ b/src/wiki/prompts/generation.ts
@@ -10,6 +10,7 @@ export const GENERATION_PROMPTS = {
 - Mentions in source (VERBATIM — preserve original language): {{mentions}}
 - Related entities: {{related_entities}}
 - Related concepts: {{related_concepts}}
+- Extraction aliases (seeds): {{extraction_aliases}}
 
 **Existing Wiki Pages (use these exact full paths when referencing):**
 {{existing_pages}}
@@ -71,6 +72,7 @@ aliases: ["Alternative name or translation"]  # REQUIRED: at least 1 alias, must
 - Mentions in source (VERBATIM — preserve original language): {{mentions}}
 - Related concepts: {{related_concepts}}
 - Related entities: {{related_entities}}
+- Extraction aliases (seeds): {{extraction_aliases}}
 
 **Existing Wiki Pages (use these exact full paths when referencing):**
 {{existing_pages}}

--- a/src/wiki/prompts/ingestion.ts
+++ b/src/wiki/prompts/ingestion.ts
@@ -12,9 +12,10 @@ export const INGESTION_PROMPTS = {
 {{granularity_instruction}}
 
 **Task Requirements:**
-0. Output the source file title (source_title) and a 100-200 word source summary (summary). These two fields appear in the FIRST round ONLY (omit them in later rounds). This does NOT mean the first round contains only these two fields: you MUST still output the entities and concepts arrays defined below, using [] when a category has no items.
-1. Extract entities and concepts that DESERVE standalone wiki pages — items another note could meaningfully link to, and that remain understandable independent of this source. Apply the wiki-link test before extracting: "Would a different note in this knowledge base link to [[this]]? Would someone search the wiki for this name?" If the answer is no, skip it. Bibliographic references (author citations like "Smith et al. 2022", study/trial names used as evidence pointers, journal article titles) are evidence containers — extract their FINDINGS as concepts instead, not the citation as an entity. Judge by wiki-graph value, not by prominence in the text
-2. Output at most {{batch_size}} items (entities + concepts total) this round
+0. [FIRST ROUND ONLY] Write a 100-200 word source summary (field: summary) and extract the source title (field: source_title). These fields must NOT appear in later rounds.
+1. In EVERY round (including the first), output both "entities" and "concepts" arrays. Use [] when a category has no items. Never omit either array.
+2. Optionally generate 1-2 aliases per entity/concept — alternative names, acronyms, translations, or common phrasings. Aliases serve as seeds for page generation and help the model avoid duplicate extractions in later rounds. The aliases field is OPTIONAL in extraction; skip it when no natural alias exists.
+3. Output at most {{batch_size}} items (entities + concepts total) this round
 3. Write a detailed, informative summary for each item (target 4-6 sentences). Include concrete information: what the entity/concept is, its role/significance in the source, key factual details, and how it relates to other items. Provide enough substance that the summary alone can seed a quality Wiki page
 4. For mentions_in_source: quote 2-4 verbatim sentences from the source where this entity/concept appears or is discussed. These quotes are critical — they provide the downstream page generator with source-grounded evidence. Include surrounding context, not just the name mention
 5. For related_entities and related_concepts: identify entities/concepts mentioned in the same context as this item. These should be other items extracted from this same source file
@@ -30,6 +31,7 @@ export const INGESTION_PROMPTS = {
     {
       "name": "Entity name — MUST be in the source's original language, NEVER translate",
       "type": "person|organization|project|product|event|location|other",
+      "aliases": ["Optional: 1-2 alternative names, abbreviations, or translations. Helps prevent duplicate extractions in later rounds.", "If provided, these will seed the page aliases."],
       "summary": "Detailed 4-6 sentence description with concrete facts: identity, role/significance, key attributes",
       "mentions_in_source": ["Verbatim sentence from source: '...'.", "Another verbatim quote: '...'."],
       "related_entities": ["Related entity names from this source"],
@@ -40,6 +42,7 @@ export const INGESTION_PROMPTS = {
     {
       "name": "Concept name — MUST be in the source's original language, NEVER translate",
       "type": "theory|method|technology|term|other",
+      "aliases": ["Optional: 1-2 alternative names, abbreviations, or translations. Helps prevent duplicate extractions in later rounds.", "If provided, these will seed the page aliases."],
       "summary": "Detailed 4-6 sentence description with concrete facts: definition, importance, relationships",
       "mentions_in_source": ["Verbatim sentence from source: '...'.", "Another verbatim quote: '...'."],
       "related_concepts": ["Related concept names from this source"],

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -11,9 +11,81 @@ import {
   WIKI_LANGUAGES,
 } from '../types';
 import { PROMPTS } from '../prompts';
-import { parseJsonResponse, matchExtractedToExisting } from '../utils';
+import { parseJsonResponse, matchExtractedToExisting, coerceToArray } from '../utils';
 import { getExistingWikiPages } from './lint-fixes';
 import { getGranularityInstruction } from './system-prompts';
+
+// ── Batch response normalization ─────────────────────────────────
+// LLMs often return irregular JSON: omitted empty arrays, non-array truthy
+// values (entities: true), or missing keys entirely. This module centralizes
+// all input validation so the main extraction loop doesn't need scattered
+// `|| []` fallbacks. Pure functions (no IO) — fully unit-testable.
+
+export type BatchValidity = 'valid' | 'empty' | 'unusable';
+
+export interface NormalizedBatch {
+  entities: EntityInfo[];
+  concepts: ConceptInfo[];
+  sourceTitle: string | null;
+  summary: string | null;
+  contradictions: ContradictionInfo[];
+  relatedPages: string[];
+  keyPoints: string[];
+}
+
+// Normalize a raw LLM batch response into a well-formed NormalizedBatch.
+// Returns a validity flag so callers can distinguish:
+//   'unusable' — both arrays absent/unfilled ⟹ abort first batch or skip
+//   'empty'    — both arrays present but zero items ⟹ signal to stop iteration
+//   'valid'    — at least one extractable item found ⟹ continue processing
+export function normalizeBatchResponse(
+  raw: Partial<SourceAnalysis> | null
+): { validity: BatchValidity; data: NormalizedBatch } {
+  if (!raw) {
+    return { validity: 'unusable', data: emptyBatch() };
+  }
+
+  const entities = coerceToArray<EntityInfo>(raw.entities)
+    .filter(e => e?.name?.trim());
+  const concepts = coerceToArray<ConceptInfo>(raw.concepts)
+    .filter(c => c?.name?.trim());
+
+  // Strip wiki-link formatting if LLM outputs [[path|name]] instead of plain name
+  const relatedPages = coerceToArray<string>(raw.related_pages).map(p => {
+    const match = String(p).match(/^\[\[(?:[^\]|]+\|)?([^\]]+)\]\]$/);
+    return match ? match[1] : p;
+  });
+
+  const data: NormalizedBatch = {
+    entities,
+    concepts,
+    sourceTitle: typeof raw.source_title === 'string' ? raw.source_title : null,
+    summary: typeof raw.summary === 'string' ? raw.summary : null,
+    contradictions: coerceToArray<ContradictionInfo>(raw.contradictions),
+    relatedPages,
+    keyPoints: coerceToArray<string>(raw.key_points),
+  };
+
+  if (entities.length === 0 && concepts.length === 0) {
+    // Both absent at key level → truly unusable; both present but empty → empty signal
+    const bothKeysAbsent = raw.entities === undefined && raw.concepts === undefined;
+    return { validity: bothKeysAbsent ? 'unusable' : 'empty', data };
+  }
+
+  return { validity: 'valid', data };
+}
+
+function emptyBatch(): NormalizedBatch {
+  return {
+    entities: [],
+    concepts: [],
+    sourceTitle: null,
+    summary: null,
+    contradictions: [],
+    relatedPages: [],
+    keyPoints: [],
+  };
+}
 
 export class SourceAnalyzer {
   constructor(private ctx: EngineContext) {}
@@ -104,7 +176,26 @@ export class SourceAnalyzer {
       if (isFirstBatch) {
         batchContext = 'This is the first extraction round. Extract the most important entities and concepts from the source.';
       } else {
-        batchContext = `This is round ${batchNum + 1} of extraction. Extract the next batch of most important entities and concepts from the remaining content. If no more items are worth extracting, return empty arrays [] for entities and concepts.`;
+        // Build already-extracted context with names and aliases to inform later rounds.
+        // This prevents the LLM from re-extracting duplicates (especially useful for
+        // small models that cannot reliably remember their own previous output).
+        const ctxLines: string[] = [];
+        for (const e of allEntities) {
+          const line = e.aliases?.length
+            ? `${e.name} (aliases: ${e.aliases.join(', ')})`
+            : e.name;
+          ctxLines.push(line);
+        }
+        for (const c of allConcepts) {
+          const line = c.aliases?.length
+            ? `${c.name} (aliases: ${c.aliases.join(', ')})`
+            : c.name;
+          ctxLines.push(line);
+        }
+        const alreadyExtracted = ctxLines.length > 0
+          ? `\n\nAlready extracted from this source:\n  [${ctxLines.join('; ')}]\n  (including abbreviations, synonyms, and translations of these names)\nDo NOT extract them again. If a candidate name is equivalent to any of the above — including their aliases — skip it.`
+          : '';
+        batchContext = `This is round ${batchNum + 1} of extraction. Extract the next batch of most important entities and concepts from the remaining content. If no more items are worth extracting, return empty arrays [] for entities and concepts.${alreadyExtracted}`;
       }
 
       const prompt = staticPrefix + batchContext + suffixTemplate
@@ -153,45 +244,38 @@ export class SourceAnalyzer {
           break;
         }
 
+        const { validity, data: norm } = normalizeBatchResponse(analysisData);
+
         if (isFirstBatch) {
-          // A first batch is only unusable when BOTH arrays are absent. A response with
-          // just one (e.g. a glossary that yields only entities) is valid: the rest of this
-          // method already tolerates a missing array via `(... || [])`, and the final guard
-          // below only aborts when nothing was extracted at all. The old `||` aborted the
-          // entire ingest whenever a model omitted an (often empty) array.
-          if (!analysisData.entities && !analysisData.concepts) {
-            console.error('❌ Round 1 missing BOTH entities and concepts (unusable response):', {
-              entities: !!analysisData.entities,
-              concepts: !!analysisData.concepts
+          if (validity === 'unusable') {
+            console.error('❌ Round 1 unusable — no entities or concepts:', {
+              entities: !!analysisData?.entities,
+              concepts: !!analysisData?.concepts
             });
             return null;
           }
-          // A model may omit an empty array entirely instead of returning [].
-          if (!Array.isArray(analysisData.entities)) analysisData.entities = [];
-          if (!Array.isArray(analysisData.concepts)) analysisData.concepts = [];
-          if (!analysisData.source_title) {
+          if (!norm.sourceTitle) {
             console.debug('Round 1 missing source_title, falling back to filename:', file.basename);
           }
           firstBatchData = analysisData;
-          sourceTitle = analysisData.source_title || file.basename;
-          sourceSummary = analysisData.summary || '';
-          contradictions = analysisData.contradictions || [];
-          relatedPages = (analysisData.related_pages || []).map(p => {
-            // Strip wiki-link formatting if LLM outputs [[path|name]] instead of plain name
-            const match = String(p).match(/^\[\[(?:[^\]|]+\|)?([^\]]+)\]\]$/);
-            return match ? match[1] : p;
-          });
-          keyPoints = analysisData.key_points || [];
+          sourceTitle = norm.sourceTitle || file.basename;
+          sourceSummary = norm.summary || '';
+          contradictions = norm.contradictions;
+          relatedPages = norm.relatedPages;
+          keyPoints = norm.keyPoints;
         }
 
-        const newEntities = (analysisData.entities || []).filter(e => {
-          if (!e.name?.trim()) return false;
+        if (validity === 'empty') {
+          console.debug(`[Batch ${batchNum + 1}] LLM returned empty arrays, stopping iteration`);
+          break;
+        }
+
+        const newEntities = norm.entities.filter(e => {
           if (extractedNames.has(e.name.trim().toLowerCase())) return false;
           return true;
         });
 
-        const newConcepts = (analysisData.concepts || []).filter(c => {
-          if (!c.name?.trim()) return false;
+        const newConcepts = norm.concepts.filter(c => {
           if (extractedNames.has(c.name.trim().toLowerCase())) return false;
           return true;
         });
@@ -221,7 +305,7 @@ export class SourceAnalyzer {
           console.debug(`[Batch ${batchNum + 1}] Response length ${response.length} 超过阈值 ${Math.round(RESPONSE_FULLNESS_THRESHOLD)}，batch_size: ${prevSize} → ${currentBatchSize}`);
         }
 
-        const rawTotal = (analysisData.entities || []).length + (analysisData.concepts || []).length;
+        const rawTotal = norm.entities.length + norm.concepts.length;
         const newTotal = cappedEntities.length + cappedConcepts.length;
         finalBatchNum = batchNum + 1;
 


### PR DESCRIPTION
## Summary

Merge after PR #62. Cherry-picked from original PR #66, resolved conflicts
with current main (the multi-round context injection was already partially
applied by a linter; this adds the core normalizeBatchResponse pure function
and coerceToArray import that were missing).

### Changes
1. **normalizeBatchResponse**: Centralize LLM output normalization (BatchValidity enum)
2. **coerceToArray**: Pure helper, fixes hidden TypeError for non-array truthy values
3. **Aliases seeding**: EntityInfo/ConceptInfo.aliases → page generation seeds
4. **Multi-round extraction context**: Inject already-extracted names+aliases
5. **Prompt task 0**: Separated field round restrictions from content requirements

### Verification
- [x] `pnpm lint` 0/0
- [x] `pnpm test` 191 pass
- [x] `npx tsc --noEmit` 0
- [x] `pnpm build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)