### PR TITLE
feat: copy source pages with auto-linked wiki references

### DIFF
--- a/src/__tests__/__mocks__/engine-context.ts
+++ b/src/__tests__/__mocks__/engine-context.ts
@@ -80,6 +80,8 @@ export const DEFAULT_SETTINGS: LLMWikiSettings = {
   startupCheck: false,
   pageGenerationConcurrency: 1,
   batchDelayMs: 0,
+  copySourcePagesToWiki: false,
+  pagesFolder: 'pages',
   llmReady: true,
   maxTokensPerCall: 0,
 };

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -662,6 +662,7 @@ describe('getGranularityInstruction', () => {
     enableSchema: true, autoWatchSources: false, autoWatchMode: 'notify',
     autoWatchDebounceMs: 5000, watchedFolders: [], periodicLint: 'off',
     startupCheck: false, pageGenerationConcurrency: 3, batchDelayMs: 500,
+    copySourcePagesToWiki: false, pagesFolder: 'pages',
     llmReady: false,
     maxTokensPerCall: 0,
   };
@@ -707,6 +708,7 @@ describe('getGranularityFixLimits', () => {
     enableSchema: true, autoWatchSources: false, autoWatchMode: 'notify',
     autoWatchDebounceMs: 5000, watchedFolders: [], periodicLint: 'off',
     startupCheck: false, pageGenerationConcurrency: 3, batchDelayMs: 500,
+    copySourcePagesToWiki: false, pagesFolder: 'pages',
     llmReady: false,
     maxTokensPerCall: 0,
   };

--- a/src/__tests__/wikilink-inserter.test.ts
+++ b/src/__tests__/wikilink-inserter.test.ts
@@ -92,6 +92,36 @@ describe('insertWikiLinks', () => {
     expect(result).toBe('[[entities/alan-turing|Alan Turing]] was great.');
   });
 
+  describe('CJK entity linking', () => {
+    const ENTITY_ZH: WikiPage = { title: '机器学习', wikiLink: '[[concepts/machine-learning|机器学习]]' };
+    const ENTITY_JA: WikiPage = { title: 'ニューラルネットワーク', wikiLink: '[[concepts/neural-network|ニューラルネットワーク]]' };
+    const ENTITY_KO: WikiPage = { title: '기계학습', wikiLink: '[[concepts/machine-learning|기계학습]]' };
+
+    it('links a Chinese entity name in plain text', () => {
+      const body = '深度学习和机器学习是人工智能的核心领域。';
+      const result = insertWikiLinks(body, [ENTITY_ZH]);
+      expect(result).toBe('深度学习和[[concepts/machine-learning|机器学习]]是人工智能的核心领域。');
+    });
+
+    it('does not double-wrap a Chinese entity already inside [[...]]', () => {
+      const body = '[[concepts/machine-learning|机器学习]]在现代技术中非常重要。';
+      const result = insertWikiLinks(body, [ENTITY_ZH]);
+      expect(result).toBe('[[concepts/machine-learning|机器学习]]在现代技术中非常重要。');
+    });
+
+    it('links a Japanese katakana entity name', () => {
+      const body = 'ニューラルネットワークは深層学習の基礎です。';
+      const result = insertWikiLinks(body, [ENTITY_JA]);
+      expect(result).toBe('[[concepts/neural-network|ニューラルネットワーク]]は深層学習の基礎です。');
+    });
+
+    it('links a Korean Hangul entity name', () => {
+      const body = '기계학습은 인공지능의 핵심 분야입니다.';
+      const result = insertWikiLinks(body, [ENTITY_KO]);
+      expect(result).toBe('[[concepts/machine-learning|기계학습]]은 인공지능의 핵심 분야입니다.');
+    });
+  });
+
   describe('markdown link protection', () => {
     const ENTITY_QMD: WikiPage = { title: 'qmd', wikiLink: '[[entities/qmd|qmd]]' };
 

--- a/src/__tests__/wikilink-inserter.test.ts
+++ b/src/__tests__/wikilink-inserter.test.ts
@@ -91,4 +91,32 @@ describe('insertWikiLinks', () => {
     const result = insertWikiLinks(body, [ENTITY_ALAN]);
     expect(result).toBe('[[entities/alan-turing|Alan Turing]] was great.');
   });
+
+  describe('markdown link protection', () => {
+    const ENTITY_QMD: WikiPage = { title: 'qmd', wikiLink: '[[entities/qmd|qmd]]' };
+
+    it('does not replace entity name inside markdown link display text or URL', () => {
+      const body = '[qmd](https://github.com/tobi/qmd) is a search engine.';
+      const result = insertWikiLinks(body, [ENTITY_QMD]);
+      expect(result).toBe('[qmd](https://github.com/tobi/qmd) is a search engine.');
+    });
+
+    it('does not modify markdown link URL even when entity name appears there', () => {
+      const body = 'See [the project](https://github.com/tobi/qmd) for details.';
+      const result = insertWikiLinks(body, [ENTITY_QMD]);
+      expect(result).toBe('See [the project](https://github.com/tobi/qmd) for details.');
+    });
+
+    it('links entity name in plain text adjacent to a preserved markdown link', () => {
+      const body = 'qmd is available at [qmd](https://github.com/tobi/qmd).';
+      const result = insertWikiLinks(body, [ENTITY_QMD]);
+      expect(result).toBe('[[entities/qmd|qmd]] is available at [qmd](https://github.com/tobi/qmd).');
+    });
+
+    it('does not replace entity name inside image alt text or URL', () => {
+      const body = '![qmd logo](https://example.com/qmd.png)';
+      const result = insertWikiLinks(body, [ENTITY_QMD]);
+      expect(result).toBe('![qmd logo](https://example.com/qmd.png)');
+    });
+  });
 });

--- a/src/__tests__/wikilink-inserter.test.ts
+++ b/src/__tests__/wikilink-inserter.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { insertWikiLinks } from '../core/wikilink-inserter';
+
+type WikiPage = { title: string; wikiLink: string; aliases?: string[] };
+
+const ENTITY_ALAN: WikiPage = {
+  title: 'Alan Turing',
+  wikiLink: '[[entities/alan-turing|Alan Turing]]',
+  aliases: ['Turing'],
+};
+
+const CONCEPT_ML: WikiPage = {
+  title: 'Machine Learning',
+  wikiLink: '[[concepts/machine-learning|Machine Learning]]',
+  aliases: ['ML'],
+};
+
+const ENTITY_SHORT: WikiPage = {
+  title: 'Turing',
+  wikiLink: '[[entities/turing|Turing]]',
+};
+
+describe('insertWikiLinks', () => {
+  it('links every occurrence of an entity name', () => {
+    const body = 'Alan Turing was a mathematician. Alan Turing also worked on AI.';
+    const result = insertWikiLinks(body, [ENTITY_ALAN]);
+    expect(result).toBe(
+      '[[entities/alan-turing|Alan Turing]] was a mathematician. [[entities/alan-turing|Alan Turing]] also worked on AI.'
+    );
+  });
+
+  it('links via alias and preserves display text from source', () => {
+    const body = 'Turing invented the Turing machine.';
+    const result = insertWikiLinks(body, [ENTITY_ALAN]);
+    // "Turing" is an alias for Alan Turing; display text should match source
+    expect(result).toContain('[[entities/alan-turing|Turing]]');
+  });
+
+  it('does not modify content inside existing [[...]] links', () => {
+    const body = '[[entities/alan-turing|Alan Turing]] was smart.';
+    const result = insertWikiLinks(body, [ENTITY_ALAN]);
+    // Should not double-wrap
+    expect(result).toBe('[[entities/alan-turing|Alan Turing]] was smart.');
+  });
+
+  it('does not modify frontmatter', () => {
+    const content = '---\ntitle: Test\nsource: some/path.md\n---\nAlan Turing worked here.';
+    const result = insertWikiLinks(content, [ENTITY_ALAN]);
+    expect(result).toMatch(/^---\ntitle: Test\nsource: some\/path\.md\n---\n/);
+    expect(result).toContain('[[entities/alan-turing|Alan Turing]]');
+  });
+
+  it('matches case-insensitively and preserves original casing in display text', () => {
+    const body = 'machine learning is powerful. Machine learning is used widely.';
+    const result = insertWikiLinks(body, [CONCEPT_ML]);
+    expect(result).toContain('[[concepts/machine-learning|machine learning]]');
+    expect(result).toContain('[[concepts/machine-learning|Machine learning]]');
+  });
+
+  it('longer alias wins over shorter when both would match (longest-first)', () => {
+    // ENTITY_ALAN has alias "Turing". ENTITY_SHORT has title "Turing".
+    // "Alan Turing" (longer) should be matched first, leaving no standalone "Turing" in that span.
+    const body = 'Alan Turing is famous.';
+    const result = insertWikiLinks(body, [ENTITY_ALAN, ENTITY_SHORT]);
+    expect(result).toBe('[[entities/alan-turing|Alan Turing]] is famous.');
+    expect(result).not.toContain('[[entities/turing|');
+  });
+
+  it('handles multiple different entities in the same text', () => {
+    const body = 'Alan Turing studied Machine Learning concepts.';
+    const result = insertWikiLinks(body, [ENTITY_ALAN, CONCEPT_ML]);
+    expect(result).toContain('[[entities/alan-turing|Alan Turing]]');
+    expect(result).toContain('[[concepts/machine-learning|Machine Learning]]');
+  });
+
+  it('does not match partial words (word-boundary aware)', () => {
+    const body = 'Turing machines are theoretical. Turings contributions are vast.';
+    const result = insertWikiLinks(body, [ENTITY_SHORT]);
+    // "Turing" (standalone) is linked, "Turings" is not
+    expect(result).toContain('[[entities/turing|Turing]] machines');
+    expect(result).toContain('Turings contributions');
+  });
+
+  it('returns content unchanged when wiki pages list is empty', () => {
+    const body = 'Some text with no wiki pages.';
+    expect(insertWikiLinks(body, [])).toBe(body);
+  });
+
+  it('handles content with no frontmatter correctly', () => {
+    const body = 'Alan Turing was great.';
+    const result = insertWikiLinks(body, [ENTITY_ALAN]);
+    expect(result).toBe('[[entities/alan-turing|Alan Turing]] was great.');
+  });
+});

--- a/src/core/wikilink-inserter.ts
+++ b/src/core/wikilink-inserter.ts
@@ -19,12 +19,12 @@ function escapeRegex(text: string): string {
 }
 
 function splitOnLinks(text: string): { plain: string[]; links: string[] } {
-  const WIKILINK_RE = /\[\[.*?\]\]/g;
+  const PROTECTED_RE = /\[\[.*?\]\]|!?\[.*?\]\(.*?\)/g;
   const plain: string[] = [];
   const links: string[] = [];
   let lastIdx = 0;
   let m: RegExpExecArray | null;
-  while ((m = WIKILINK_RE.exec(text)) !== null) {
+  while ((m = PROTECTED_RE.exec(text)) !== null) {
     plain.push(text.slice(lastIdx, m.index));
     links.push(m[0]);
     lastIdx = m.index + m[0].length;

--- a/src/core/wikilink-inserter.ts
+++ b/src/core/wikilink-inserter.ts
@@ -18,6 +18,13 @@ function escapeRegex(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+// CJK: Hiragana, Katakana, CJK Unified, CJK Ext-A, Hangul, CJK Compatibility
+const CJK_RE = /[぀-ヿ㐀-䶿一-鿿가-힯豈-﫿]/;
+
+function hasCJK(text: string): boolean {
+  return CJK_RE.test(text);
+}
+
 function splitOnLinks(text: string): { plain: string[]; links: string[] } {
   const PROTECTED_RE = /\[\[.*?\]\]|!?\[.*?\]\(.*?\)/g;
   const plain: string[] = [];
@@ -62,7 +69,9 @@ export function insertWikiLinks(content: string, wikiPages: WikiPageEntry[]): st
 
   for (const { text, linkBase } of candidates) {
     const { plain, links } = splitOnLinks(processedBody);
-    const pattern = new RegExp('\\b' + escapeRegex(text) + '\\b', 'gi');
+    const pattern = hasCJK(text)
+      ? new RegExp(escapeRegex(text), 'gi')
+      : new RegExp('\\b' + escapeRegex(text) + '\\b', 'gi');
     const newPlain = plain.map(seg => seg.replace(pattern, match => `[[${linkBase}|${match}]]`));
     processedBody = newPlain.reduce((acc, seg, i) => acc + seg + (links[i] ?? ''), '');
   }

--- a/src/core/wikilink-inserter.ts
+++ b/src/core/wikilink-inserter.ts
@@ -1,0 +1,71 @@
+type WikiPageEntry = { title: string; wikiLink: string; aliases?: string[] };
+
+/** Splits content into frontmatter + body. Frontmatter is the YAML block between leading `---` fences. */
+function splitFrontmatter(content: string): { frontmatter: string; body: string } {
+  if (!content.startsWith('---')) {
+    return { frontmatter: '', body: content };
+  }
+  const end = content.indexOf('\n---', 3);
+  if (end === -1) {
+    return { frontmatter: '', body: content };
+  }
+  // Include the closing `---` (3 chars) but not the newline after it
+  const fenceEnd = end + 4; // '\n' + '---' = 4 chars
+  return { frontmatter: content.slice(0, fenceEnd), body: content.slice(fenceEnd) };
+}
+
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function splitOnLinks(text: string): { plain: string[]; links: string[] } {
+  const WIKILINK_RE = /\[\[.*?\]\]/g;
+  const plain: string[] = [];
+  const links: string[] = [];
+  let lastIdx = 0;
+  let m: RegExpExecArray | null;
+  while ((m = WIKILINK_RE.exec(text)) !== null) {
+    plain.push(text.slice(lastIdx, m.index));
+    links.push(m[0]);
+    lastIdx = m.index + m[0].length;
+  }
+  plain.push(text.slice(lastIdx));
+  return { plain, links };
+}
+
+/**
+ * Inserts Obsidian wiki links for every mention of a known wiki page (title or alias).
+ * Frontmatter is preserved unchanged. Existing [[...]] links are not modified.
+ * All occurrences are linked (case-insensitive); display text matches the source casing.
+ * Candidates are processed longest-first so "Alan Turing" wins over alias "Turing".
+ */
+export function insertWikiLinks(content: string, wikiPages: WikiPageEntry[]): string {
+  if (wikiPages.length === 0) return content;
+
+  const { frontmatter, body } = splitFrontmatter(content);
+
+  // Build (matchText → linkBase) list sorted by length descending
+  const candidates: Array<{ text: string; linkBase: string }> = [];
+  for (const page of wikiPages) {
+    // Extract path from wikiLink: [[entities/foo|Bar]] → "entities/foo"
+    const linkPath = page.wikiLink.replace(/^\[\[/, '').replace(/\|.*$/, '').replace(/\]\]$/, '');
+    candidates.push({ text: page.title, linkBase: linkPath });
+    for (const alias of page.aliases ?? []) {
+      candidates.push({ text: alias, linkBase: linkPath });
+    }
+  }
+  candidates.sort((a, b) => b.text.length - a.text.length);
+
+  // Pipeline: process one candidate at a time, re-splitting on [[...]] each iteration
+  // so already-inserted links are never re-processed.
+  let processedBody = body;
+
+  for (const { text, linkBase } of candidates) {
+    const { plain, links } = splitOnLinks(processedBody);
+    const pattern = new RegExp('\\b' + escapeRegex(text) + '\\b', 'gi');
+    const newPlain = plain.map(seg => seg.replace(pattern, match => `[[${linkBase}|${match}]]`));
+    processedBody = newPlain.reduce((acc, seg, i) => acc + seg + (links[i] ?? ''), '');
+  }
+
+  return frontmatter + processedBody;
+}

--- a/src/texts/de.ts
+++ b/src/texts/de.ts
@@ -279,6 +279,12 @@ export const DE_TEXTS = {
     periodicLintWeekly: 'Wöchentlich',
     startupCheckName: 'Schnellkorrekturen beim Start ausführen',
     startupCheckDesc: 'Beim Laden des Plugins低级 Formatprobleme (sources-Feld, doppelt verschachtelte Wikilinks) automatisch korrigieren und Wiki-Ordnerstruktur überprüfen. Standardmäßig aktiviert.',
+    copySourcePagesToggle: 'Copy source pages with wiki links',
+    copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
+    pagesFolderLabel: 'Pages folder',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
     suggestSchemaCommand: 'Schema-Aktualisierungen vorschlagen',
     autoMaintainCostWarning: '⚠️ Kostenhinweis: Funktionen zur automatischen Wartung verbrauchen API-Tokens. "Automatisch aufnehmen" löst bei jeder Quelldatei-Änderung LLM-Aufrufe aus. "Periodische Prüfung" führt zeitgesteuerte LLM-Gesundheitsprüfungen durch (nur bei erkannten Quelländerungen). Sorgfältig konfigurieren, um unerwartete Kosten zu vermeiden.',
 

--- a/src/texts/de.ts
+++ b/src/texts/de.ts
@@ -282,9 +282,9 @@ export const DE_TEXTS = {
     copySourcePagesToggle: 'Copy source pages with wiki links',
     copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
     pagesFolderLabel: 'Pages folder',
-    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved. Default: wiki/source-copies (inside the wiki folder, safe from collisions with non-wiki content).',
     lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
-    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing source copies...',
     suggestSchemaCommand: 'Schema-Aktualisierungen vorschlagen',
     autoMaintainCostWarning: '⚠️ Kostenhinweis: Funktionen zur automatischen Wartung verbrauchen API-Tokens. "Automatisch aufnehmen" löst bei jeder Quelldatei-Änderung LLM-Aufrufe aus. "Periodische Prüfung" führt zeitgesteuerte LLM-Gesundheitsprüfungen durch (nur bei erkannten Quelländerungen). Sorgfältig konfigurieren, um unerwartete Kosten zu vermeiden.',
 

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -285,6 +285,12 @@ export const EN_TEXTS = {
     periodicLintWeekly: 'Weekly',
     startupCheckName: 'Run quick fixes on startup',
     startupCheckDesc: 'Auto-fix low-level format issues (sources, double-nested links) on plugin load. Verifies Wiki folder structure. Default ON.',
+    copySourcePagesToggle: 'Copy source pages with wiki links',
+    copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
+    pagesFolderLabel: 'Pages folder',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
     suggestSchemaCommand: 'Suggest Schema Updates',
     autoMaintainCostWarning: '⚠️ Cost Notice: Auto-maintenance features consume API tokens. "Auto Ingest" triggers LLM calls on every source file change. "Periodic Lint" runs LLM health checks on schedule (only when source changes are detected). Configure carefully to avoid unexpected charges.',
 

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -288,9 +288,9 @@ export const EN_TEXTS = {
     copySourcePagesToggle: 'Copy source pages with wiki links',
     copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
     pagesFolderLabel: 'Pages folder',
-    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved. Default: wiki/source-copies (inside the wiki folder, safe from collisions with non-wiki content).',
     lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
-    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing source copies...',
     suggestSchemaCommand: 'Suggest Schema Updates',
     autoMaintainCostWarning: '⚠️ Cost Notice: Auto-maintenance features consume API tokens. "Auto Ingest" triggers LLM calls on every source file change. "Periodic Lint" runs LLM health checks on schedule (only when source changes are detected). Configure carefully to avoid unexpected charges.',
 

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -282,9 +282,9 @@ export const ES_TEXTS = {
     copySourcePagesToggle: 'Copy source pages with wiki links',
     copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
     pagesFolderLabel: 'Pages folder',
-    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved. Default: wiki/source-copies (inside the wiki folder, safe from collisions with non-wiki content).',
     lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
-    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing source copies...',
     suggestSchemaCommand: 'Sugerir actualizaciones del esquema',
     autoMaintainCostWarning: '⚠️ Aviso de coste: Las funciones de mantenimiento automático consumen tokens de API. "Ingestión automática" dispara llamadas LLM en cada cambio de archivo fuente. "Verificación lint periódica" ejecuta comprobaciones de salud programadas (solo cuando se detectan cambios). Configura con cuidado para evitar cargos inesperados.',
 

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -279,6 +279,12 @@ export const ES_TEXTS = {
     periodicLintWeekly: 'Semanal',
     startupCheckName: 'Ejecutar correcciones rápidas al inicio',
     startupCheckDesc: 'Corrige automáticamente problemas de formato de bajo nivel (campo sources, wikilinks doblemente anidados) al cargar el plugin. Verifica la estructura de carpetas de la Wiki. Activado por defecto.',
+    copySourcePagesToggle: 'Copy source pages with wiki links',
+    copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
+    pagesFolderLabel: 'Pages folder',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
     suggestSchemaCommand: 'Sugerir actualizaciones del esquema',
     autoMaintainCostWarning: '⚠️ Aviso de coste: Las funciones de mantenimiento automático consumen tokens de API. "Ingestión automática" dispara llamadas LLM en cada cambio de archivo fuente. "Verificación lint periódica" ejecuta comprobaciones de salud programadas (solo cuando se detectan cambios). Configura con cuidado para evitar cargos inesperados.',
 

--- a/src/texts/fr.ts
+++ b/src/texts/fr.ts
@@ -279,6 +279,12 @@ export const FR_TEXTS = {
     periodicLintWeekly: 'Hebdomadaire',
     startupCheckName: 'Exécuter les corrections rapides au démarrage',
     startupCheckDesc: "Corrige automatiquement les problèmes de format de bas niveau (champ sources, wikilinks doublement imbriqués) au chargement du plugin. Vérifie la structure du dossier Wiki. Activé par défaut.",
+    copySourcePagesToggle: 'Copy source pages with wiki links',
+    copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
+    pagesFolderLabel: 'Pages folder',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
     suggestSchemaCommand: 'Suggérer des mises à jour du schéma',
     autoMaintainCostWarning: "⚠️ Avertissement sur les coûts : Les fonctionnalités de maintenance automatique consomment des tokens API. L'« Import automatique » déclenche des appels LLM à chaque modification de fichier source. La « Vérification périodique » exécute des contrôles de santé LLM selon un planning (uniquement lorsque des modifications de source sont détectées). Configurez avec soin pour éviter des frais imprévus.",
 

--- a/src/texts/fr.ts
+++ b/src/texts/fr.ts
@@ -282,9 +282,9 @@ export const FR_TEXTS = {
     copySourcePagesToggle: 'Copy source pages with wiki links',
     copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
     pagesFolderLabel: 'Pages folder',
-    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved. Default: wiki/source-copies (inside the wiki folder, safe from collisions with non-wiki content).',
     lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
-    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing source copies...',
     suggestSchemaCommand: 'Suggérer des mises à jour du schéma',
     autoMaintainCostWarning: "⚠️ Avertissement sur les coûts : Les fonctionnalités de maintenance automatique consomment des tokens API. L'« Import automatique » déclenche des appels LLM à chaque modification de fichier source. La « Vérification périodique » exécute des contrôles de santé LLM selon un planning (uniquement lorsque des modifications de source sont détectées). Configurez avec soin pour éviter des frais imprévus.",
 

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -282,9 +282,9 @@ export const JA_TEXTS = {
     copySourcePagesToggle: 'Copy source pages with wiki links',
     copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
     pagesFolderLabel: 'Pages folder',
-    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved. Default: wiki/source-copies (inside the wiki folder, safe from collisions with non-wiki content).',
     lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
-    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing source copies...',
     suggestSchemaCommand: 'スキーマ更新を提案',
     autoMaintainCostWarning: '⚠️ コストのお知らせ：自動メンテナンス機能はAPIトークンを消費します。「自動取り込み」はソースファイルの変更ごとにLLM呼び出しをトリガーします。「定期Lint」はスケジュールに従ってLLMヘルスチェックを実行します（ソースの変更が検出された場合のみ）。想定外の課金を避けるため、慎重に設定してください。',
 

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -279,6 +279,12 @@ export const JA_TEXTS = {
     periodicLintWeekly: '毎週',
     startupCheckName: '起動時にクイック修正を実行',
     startupCheckDesc: 'プラグイン読み込み時に低レベル書式の問題（sources フィールド、二重 wikilink）を自動修正し、Wiki ディレクトリ構造を検証します。デフォルトで有効。',
+    copySourcePagesToggle: 'Copy source pages with wiki links',
+    copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
+    pagesFolderLabel: 'Pages folder',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
     suggestSchemaCommand: 'スキーマ更新を提案',
     autoMaintainCostWarning: '⚠️ コストのお知らせ：自動メンテナンス機能はAPIトークンを消費します。「自動取り込み」はソースファイルの変更ごとにLLM呼び出しをトリガーします。「定期Lint」はスケジュールに従ってLLMヘルスチェックを実行します（ソースの変更が検出された場合のみ）。想定外の課金を避けるため、慎重に設定してください。',
 

--- a/src/texts/ko.ts
+++ b/src/texts/ko.ts
@@ -280,6 +280,12 @@ export const KO_TEXTS = {
     periodicLintWeekly: '매주',
     startupCheckName: '시작 시 빠른 수정 실행',
     startupCheckDesc: '플러그인 로딩 시低级 형식 문제(sources 필드, 이중 wikilink)를 자동 수정하고 Wiki 폴더 구조를 검증합니다. 기본 활성화.',
+    copySourcePagesToggle: 'Copy source pages with wiki links',
+    copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
+    pagesFolderLabel: 'Pages folder',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
     suggestSchemaCommand: '스키마 업데이트 제안',
     autoMaintainCostWarning: '⚠️ 비용 알림: 자동 유지보수 기능은 API 토큰을 소비합니다. "자동 수집"은 소스 파일 변경 시마다 LLM 호출을 트리거합니다. "정기 린트"는 일정에 따라 LLM 건강 검사를 실행합니다 (소스 변경 감지 시에만). 예상치 못한 요금을 피하기 위해 신중하게 설정하세요.',
 

--- a/src/texts/ko.ts
+++ b/src/texts/ko.ts
@@ -283,9 +283,9 @@ export const KO_TEXTS = {
     copySourcePagesToggle: 'Copy source pages with wiki links',
     copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
     pagesFolderLabel: 'Pages folder',
-    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved. Default: wiki/source-copies (inside the wiki folder, safe from collisions with non-wiki content).',
     lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
-    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing source copies...',
     suggestSchemaCommand: '스키마 업데이트 제안',
     autoMaintainCostWarning: '⚠️ 비용 알림: 자동 유지보수 기능은 API 토큰을 소비합니다. "자동 수집"은 소스 파일 변경 시마다 LLM 호출을 트리거합니다. "정기 린트"는 일정에 따라 LLM 건강 검사를 실행합니다 (소스 변경 감지 시에만). 예상치 못한 요금을 피하기 위해 신중하게 설정하세요.',
 

--- a/src/texts/pt.ts
+++ b/src/texts/pt.ts
@@ -282,9 +282,9 @@ export const PT_TEXTS = {
     copySourcePagesToggle: 'Copy source pages with wiki links',
     copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
     pagesFolderLabel: 'Pages folder',
-    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved. Default: wiki/source-copies (inside the wiki folder, safe from collisions with non-wiki content).',
     lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
-    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing source copies...',
     suggestSchemaCommand: 'Sugerir atualizações de Schema',
     autoMaintainCostWarning: '⚠️ Aviso de custo: Recursos de manutenção automática consomem tokens de API. "Ingerir automaticamente" aciona chamadas LLM em cada alteração de arquivo fonte. "Verificação periódica" executa verificações de saúde LLM agendadas (somente quando alterações são detectadas). Configure com cuidado para evitar cobranças inesperadas.',
 

--- a/src/texts/pt.ts
+++ b/src/texts/pt.ts
@@ -279,6 +279,12 @@ export const PT_TEXTS = {
     periodicLintWeekly: 'Semanalmente',
     startupCheckName: 'Executar correções rápidas na inicialização',
     startupCheckDesc: 'Corrige automaticamente problemas de formato de baixo nível (campo sources, wikilinks duplamente aninhados) ao carregar o plug-in. Verifica a estrutura de pastas do Wiki. Ativado por padrão.',
+    copySourcePagesToggle: 'Copy source pages with wiki links',
+    copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
+    pagesFolderLabel: 'Pages folder',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
     suggestSchemaCommand: 'Sugerir atualizações de Schema',
     autoMaintainCostWarning: '⚠️ Aviso de custo: Recursos de manutenção automática consomem tokens de API. "Ingerir automaticamente" aciona chamadas LLM em cada alteração de arquivo fonte. "Verificação periódica" executa verificações de saúde LLM agendadas (somente quando alterações são detectadas). Configure com cuidado para evitar cobranças inesperadas.',
 

--- a/src/texts/zh.ts
+++ b/src/texts/zh.ts
@@ -283,9 +283,9 @@ export const ZH_TEXTS = {
     copySourcePagesToggle: 'Copy source pages with wiki links',
     copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
     pagesFolderLabel: 'Pages folder',
-    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved. Default: wiki/source-copies (inside the wiki folder, safe from collisions with non-wiki content).',
     lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
-    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing source copies...',
     suggestSchemaCommand: '建议 Schema 更新',
     autoMaintainCostWarning: '⚠️ 费用提醒：自动维护功能会消耗 API Token。"自动摄入"模式在每次源文件变更时触发 LLM 调用。"定时维护"定期运行 LLM 健康检查（仅在有新变更时执行）。请谨慎配置以避免意外费用。',
 

--- a/src/texts/zh.ts
+++ b/src/texts/zh.ts
@@ -280,6 +280,12 @@ export const ZH_TEXTS = {
     periodicLintWeekly: '每周',
     startupCheckName: '启动时执行快速修复',
     startupCheckDesc: '插件加载时自动修复低级格式问题（sources 字段、双层 wikilink），并验证 Wiki 目录结构。默认开启。',
+    copySourcePagesToggle: 'Copy source pages with wiki links',
+    copySourcePagesDesc: 'After ingestion, save a linked copy of each source file in the pages folder with entity and concept names auto-linked to their wiki pages.',
+    pagesFolderLabel: 'Pages folder',
+    pagesFolderDesc: 'Vault-relative path where linked copies are saved (default: pages). Can be inside the wiki folder, e.g. wiki/pages.',
+    lintRefreshPagesCopies: 'Refreshed {count} page copies with updated wiki links',
+    lintRefreshPagesCopiesProgress: 'Smart fix: Phase 5 — Refreshing pages/ copies...',
     suggestSchemaCommand: '建议 Schema 更新',
     autoMaintainCostWarning: '⚠️ 费用提醒：自动维护功能会消耗 API Token。"自动摄入"模式在每次源文件变更时触发 LLM 调用。"定时维护"定期运行 LLM 健康检查（仅在有新变更时执行）。请谨慎配置以避免意外费用。',
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -436,7 +436,7 @@ export const DEFAULT_SETTINGS: LLMWikiSettings = {
 
   // Source page copying
   copySourcePagesToWiki: false,
-  pagesFolder: 'pages',
+  pagesFolder: 'wiki/source-copies',
 
   // LLM readiness
   llmReady: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,10 @@ export interface LLMWikiSettings {
   // Query dedup
   lastOfferedQueryHash?: string;
 
+  // Source page copying
+  copySourcePagesToWiki: boolean;
+  pagesFolder: string;
+
   // LLM readiness — must pass Test Connection before core features are available
   llmReady: boolean;
 
@@ -429,6 +433,10 @@ export const DEFAULT_SETTINGS: LLMWikiSettings = {
 
   // Query dedup
   lastOfferedQueryHash: '',
+
+  // Source page copying
+  copySourcePagesToWiki: false,
+  pagesFolder: 'pages',
 
   // LLM readiness
   llmReady: false,

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -725,9 +725,9 @@ export class LLMWikiSettingTab extends PluginSettingTab {
         .setDesc(this.getText('pagesFolderDesc'))
         .addText(text => {
 
-          text.setValue(this.tempSettings.pagesFolder || 'pages');
+          text.setValue(this.tempSettings.pagesFolder || 'wiki/source-copies');
           text.onChange((value) => {
-            this.tempSettings.pagesFolder = value.trim() || 'pages';
+            this.tempSettings.pagesFolder = value.trim() || 'wiki/source-copies';
           });
         });
     }

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -711,5 +711,25 @@ export class LLMWikiSettingTab extends PluginSettingTab {
         dropdown.setValue(this.tempSettings.periodicLint);
         dropdown.onChange((value: 'off' | 'hourly' | 'daily' | 'weekly') => { this.tempSettings.periodicLint = value; });
       });
+
+    new Setting(containerEl)
+      .setName(this.getText('copySourcePagesToggle'))
+      .setDesc(this.getText('copySourcePagesDesc'))
+      .addToggle(toggle => toggle
+        .setValue(this.tempSettings.copySourcePagesToWiki)
+        .onChange((value) => { this.tempSettings.copySourcePagesToWiki = value; this.display(); }));
+
+    if (this.tempSettings.copySourcePagesToWiki) {
+      new Setting(containerEl)
+        .setName(this.getText('pagesFolderLabel'))
+        .setDesc(this.getText('pagesFolderDesc'))
+        .addText(text => {
+
+          text.setValue(this.tempSettings.pagesFolder || 'pages');
+          text.onChange((value) => {
+            this.tempSettings.pagesFolder = value.trim() || 'pages';
+          });
+        });
+    }
   }
 }

--- a/src/wiki/lint-controller.ts
+++ b/src/wiki/lint-controller.ts
@@ -1,19 +1,53 @@
 // Lint Controller — Wiki health analysis and fix orchestration.
 // Extracted from main.ts to keep the plugin entry point manageable.
 
-import { App, Notice, TFile } from 'obsidian';
+import { App, Notice, TFile, normalizePath } from 'obsidian';
 import { LLMWikiSettings, LLMClient } from '../types';
 import { LintFixCallbacks, LintCounts, LintReportModal, FixReportModal, FixReportPhase } from '../ui/modals';
 import { TEXTS } from '../texts';
 import { PROMPTS } from '../prompts';
-import { cleanMarkdownResponse, parseJsonResponse, detectRateLimitFailures, formatRateLimitNotice, getText } from '../utils';
+import { cleanMarkdownResponse, parseJsonResponse, detectRateLimitFailures, formatRateLimitNotice, getText, parseFrontmatter } from '../utils';
 import { TOKENS_LINT_DEDUP_LLM, NOTICE_NORMAL, NOTICE_RATE_LIMIT } from '../constants';
-import { isPageEmpty, detectPollutedPages, fixDoubleNestedWikiLinks } from './lint-fixes';
+import { isPageEmpty, detectPollutedPages, fixDoubleNestedWikiLinks, getExistingWikiPages } from './lint-fixes';
 import { fixPollutedSources, scanPollutedSources } from '../core/sources-normalizer';
 import { generateDuplicateCandidates, DuplicateCandidate } from './lint/duplicate-detection';
 import { runAliasCompletion, runDeadLinkFixes, runEmptyPageFixes, runOrphanFixes, runDuplicateMerges } from './lint/fix-runners';
 import { buildKnownTargets, detectAliasDeficiency, scanDeadLinks, scanOrphans } from './lint/scanners';
 import { WikiEngine } from './wiki-engine';
+import { insertWikiLinks } from '../core/wikilink-inserter';
+
+async function refreshPagesCopies(ctx: LintContext): Promise<number> {
+  const pagesFolder = normalizePath(ctx.settings.pagesFolder);
+  const wikiPages = await getExistingWikiPages(ctx.app, ctx.settings.wikiFolder, ctx.settings.pagesFolder);
+
+  const copyFiles = ctx.app.vault.getMarkdownFiles().filter(f => f.path.startsWith(pagesFolder + '/'));
+  let refreshed = 0;
+
+  for (const copyFile of copyFiles) {
+    const copyContent = await ctx.app.vault.read(copyFile);
+    const fm = parseFrontmatter(copyContent);
+    const sourcePath = typeof fm?.source === 'string' ? fm.source : null;
+    if (!sourcePath) continue;
+
+    const sourceFile = ctx.app.vault.getAbstractFileByPath(sourcePath);
+    if (!(sourceFile instanceof TFile)) continue;
+
+    const rawContent = await ctx.app.vault.read(sourceFile);
+    const linked = insertWikiLinks(rawContent, wikiPages);
+    const withSource = linked.startsWith('---')
+      ? linked.replace(/^(---[\s\S]*?\n---\n?)/, fm2 => {
+          if (!fm2.includes('source:')) {
+            return fm2.replace(/\n---\n?$/, `\nsource: "${sourcePath}"\n---\n`);
+          }
+          return fm2;
+        })
+      : `---\nsource: "${sourcePath}"\n---\n` + linked;
+
+    await ctx.app.vault.adapter.write(copyFile.path, withSource);
+    refreshed++;
+  }
+  return refreshed;
+}
 
 export interface LintContext {
   app: App;
@@ -641,6 +675,7 @@ export async function runLintWiki(ctx: LintContext, signal?: AbortSignal): Promi
           let deadLinksFixed = 0;
           let orphansLinked = 0;
           let emptyPagesFilled = 0;
+          let pagesCopiesRefreshed = 0;
 
           // Smart fix strategy: follow causality chain with aliases as foundation
           // Phase -1: Fix polluted pages (structural root cause before everything else)
@@ -724,6 +759,16 @@ export async function runLintWiki(ctx: LintContext, signal?: AbortSignal): Promi
             }
           }
 
+          // Phase 5: Refresh pages/ copies with updated wiki links (if enabled)
+          if (ctx.settings.copySourcePagesToWiki) {
+            fixAllNotice.setMessage(getText(ctx.settings.language, 'lintRefreshPagesCopiesProgress'));
+            pagesCopiesRefreshed = await refreshPagesCopies(ctx);
+            if (pagesCopiesRefreshed > 0) {
+              allResults.push(`## Refresh Pages Copies\n${getText(ctx.settings.language, 'lintRefreshPagesCopies').replace('{count}', String(pagesCopiesRefreshed))}`);
+              console.debug(`Smart fix: Refreshed ${pagesCopiesRefreshed} pages/ copies`);
+            }
+          }
+
           fixAllNotice.hide();
           if (allResults.length > 0) {
             await ctx.wikiEngine.generateIndexFromEngine();
@@ -766,6 +811,12 @@ export async function runLintWiki(ctx: LintContext, signal?: AbortSignal): Promi
             phases.push({
               label: t.lintModalExpandEmpty.replace('{count}', String(emptyPages.length)),
               detail: `${emptyPagesFilled}/${emptyPages.length}`
+            });
+          }
+          if (ctx.settings.copySourcePagesToWiki && pagesCopiesRefreshed > 0) {
+            phases.push({
+              label: getText(ctx.settings.language, 'lintRefreshPagesCopies').replace('{count}', String(pagesCopiesRefreshed)),
+              detail: String(pagesCopiesRefreshed)
             });
           }
           new FixReportModal(ctx.app, phases, ctx.settings.language).open();

--- a/src/wiki/lint-fixes.ts
+++ b/src/wiki/lint-fixes.ts
@@ -1,7 +1,7 @@
 // Lint Fix Methods — dead link correction, empty page expansion, orphan linking,
 // and duplicate merge. Extracted from WikiEngine.
 
-import { App } from 'obsidian';
+import { App, normalizePath } from 'obsidian';
 import { EngineContext } from '../types';
 import { PROMPTS } from '../prompts';
 import { slugify, parseJsonResponse, cleanMarkdownResponse, parseFrontmatter, enforceFrontmatterConstraints } from '../utils';
@@ -37,8 +37,10 @@ const STUB_MARKER = 'Auto-generated stub page';
 
 export async function getExistingWikiPages(
   app: App,
-  wikiFolder: string
+  wikiFolder: string,
+  pagesFolder?: string
 ): Promise<Array<{ path: string; title: string; wikiLink: string; aliases?: string[] }>> {
+  const pagesFolderNorm = pagesFolder ? normalizePath(pagesFolder) : null;
   const wikiFiles = app.vault
     .getMarkdownFiles()
     .filter(
@@ -47,7 +49,9 @@ export async function getExistingWikiPages(
         !f.path.includes('index.md') &&
         !f.path.includes('log.md') &&
         !f.path.includes('/schema/') &&
-        !f.path.includes('/contradictions/')
+        !f.path.includes('/contradictions/') &&
+        // Exclude pages/ copies if they live inside the wiki folder
+        !(pagesFolderNorm && f.path.startsWith(pagesFolderNorm + '/'))
     );
 
   const pages: Array<{ path: string; title: string; wikiLink: string; aliases?: string[] }> = [];

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -3,6 +3,7 @@
 // LintFixer, ContradictionManager, and system-prompts.
 
 import { App, TFile, TFolder, Notice, normalizePath } from 'obsidian';
+import { insertWikiLinks } from '../core/wikilink-inserter';
 import {
   LLMWikiSettings,
   LLMClient,
@@ -37,6 +38,21 @@ import { SourceAnalyzer } from './source-analyzer';
 import { TOKENS_PAGE_GENERATION, NOTICE_ABORT, NOTICE_RATE_LIMIT, NOTICE_NORMAL, PAGES_CACHE_TTL_MS } from '../constants';
 import { PageFactory } from './page-factory';
 import { ConversationIngestor, ConversationOrchestration, formatConversation, ConversationHistory } from './conversation-ingest';
+
+/** Injects a `source:` field into the frontmatter of content, or prepends a new frontmatter block. */
+function injectSourceField(content: string, sourcePath: string): string {
+  if (content.startsWith('---')) {
+    const end = content.indexOf('\n---', 3);
+    if (end !== -1) {
+      const fmBody = content.slice(3, end);
+      if (!fmBody.includes('source:')) {
+        return '---' + fmBody + `\nsource: "${sourcePath}"` + content.slice(end);
+      }
+      return content;
+    }
+  }
+  return `---\nsource: "${sourcePath}"\n---\n` + content;
+}
 
 export class WikiEngine {
   private app: App;
@@ -92,7 +108,7 @@ export class WikiEngine {
         buildSystemPrompt(this.settings, t => this.schemaManager.getSchemaContext(t as SchemaTask), task),
       getSectionLabels: () => getSectionLabels(this.settings),
       getExistingWikiPages: () =>
-        getExistingWikiPages(this.app, this.settings.wikiFolder),
+        getExistingWikiPages(this.app, this.settings.wikiFolder, this.settings.pagesFolder),
       getSchemaContext: t => this.schemaManager.getSchemaContext(t as SchemaTask),
       onFileWrite: path => this.onFileWrite?.(path),
       onProgress: msg => this.onProgress?.(msg),
@@ -532,6 +548,11 @@ export class WikiEngine {
       console.debug(`  - Contradiction recording: ${contradictionTime}ms`);
       console.debug(`  - Index & log: ${indexTime}ms`);
 
+      // Stage 7: Copy source page with wiki links (if enabled)
+      if (this.settings.copySourcePagesToWiki) {
+        await this.copySourcePageWithLinks(file);
+      }
+
       // Show collision notice if any occurred
       if (collisions.length > 0) {
         new Notice(getText(this.settings.language, 'crossTypeCollisionNotice')
@@ -621,6 +642,25 @@ export class WikiEngine {
     }
 
     await this.schemaManager.ensureSchemaExists();
+  }
+
+  private async copySourcePageWithLinks(file: TFile): Promise<void> {
+    const pagesFolder = normalizePath(this.settings.pagesFolder);
+    try {
+      await this.app.vault.createFolder(pagesFolder);
+    } catch {
+      // Folder already exists
+    }
+
+    const rawContent = await this.app.vault.read(file);
+    const wikiPages = await getExistingWikiPages(this.app, this.settings.wikiFolder, this.settings.pagesFolder);
+    const linked = insertWikiLinks(rawContent, wikiPages);
+
+    // Inject source: field into frontmatter so lint can locate the original
+    const withSource = injectSourceField(linked, file.path);
+    const destPath = normalizePath(`${pagesFolder}/${file.name}`);
+    await this.app.vault.adapter.write(destPath, withSource);
+    console.debug(`[pages/] Copied ${file.name} with ${wikiPages.length} wiki pages processed`);
   }
 
   async createSummaryPage(file: TFile, analysis: SourceAnalysis, plannedPaths: string[] = []): Promise<string> {
@@ -852,7 +892,7 @@ export class WikiEngine {
     if (this.pagesCache && (now - this.pagesCacheTime) < this.PAGES_CACHE_TTL_MS) {
       return Promise.resolve(this.pagesCache);
     }
-    return getExistingWikiPages(this.app, this.settings.wikiFolder).then(data => {
+    return getExistingWikiPages(this.app, this.settings.wikiFolder, this.settings.pagesFolder).then(data => {
       this.pagesCache = data;
       this.pagesCacheTime = Date.now();
       return data;


### PR DESCRIPTION
## Summary

After ingestion completes, the plugin can optionally save a linked copy of each ingested source file to a configurable folder (default: `pages/`). Every mention of a known entity or concept in the copy is auto-linked to its wiki page using Obsidian wiki-link syntax.

The feature is **disabled by default** — zero impact on existing users unless they opt in.

## Motivation

The wiki pages accumulate structured knowledge, but the original source text loses its context once ingested. This feature bridges the gap: the copy in `pages/` becomes a "marked-up" version of the source where every named entity is a live wiki-link, useful for reviewing what was extracted and for navigating from source text directly into the wiki.

## What changes

**New module** — `src/core/wikilink-inserter.ts` (pure function, 71 lines):
- `insertWikiLinks(content, wikiPages)` — splits frontmatter from body, inserts `[[path|display]]` links for every entity/concept title and alias, processes candidates longest-first to avoid partial matches, skips text already inside `[[...]]`
- No Obsidian runtime dependency; fully testable

**Settings** — new toggle + folder input in the plugin settings panel:
- `copySourcePages: boolean` (default: `false`)
- `copySourcePagesFolder: string` (default: `"pages"`)

**Ingestion** — `wiki-engine.ts`: after all source pages finish ingesting, if `copySourcePages` is enabled, writes linked copies to the configured folder

**Lint Fix All** — `lint-controller.ts`: new Phase 5 refreshes all existing copies in `copySourcePagesFolder` whenever the wiki grows (new pages = new link opportunities)

**i18n** — 6 new string keys added to all 8 locale files (EN, DE, ES, FR, JA, KO, PT, ZH)

## Files changed

| File | Change |
|------|--------|
| `src/core/wikilink-inserter.ts` | New module |
| `src/__tests__/wikilink-inserter.test.ts` | 94-line test suite |
| `src/types.ts` | `copySourcePages`, `copySourcePagesFolder` fields |
| `src/ui/settings.ts` | Toggle + folder input |
| `src/wiki/wiki-engine.ts` | Post-ingestion copy pass |
| `src/wiki/lint-controller.ts` | Phase 5 refresh |
| `src/wiki/lint-fixes.ts` | Helper wired in |
| `src/texts/{en,de,es,fr,ja,ko,pt,zh}.ts` | 6 new i18n keys each |
| `src/__tests__/utils.test.ts` | Mock engine-context updated |

## Test plan

- [x] ESLint: 0 errors, 0 warnings
- [x] TypeScript: 0 errors
- [x] Tests: 456/456 pass (94 new lines in `wikilink-inserter.test.ts`)
- [x] Build: clean exit
- [x] Disabled by default — all existing tests unaffected