### PR TITLE
docs: v1.20.0 README completeness + architecture sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,13 +82,14 @@ All v1.18.x P0 items closed. Next window opens with post-v1.19.0 feedback.
 src/
 ├── main.ts                         # Plugin entry point
 ├── types.ts                        # Shared types + EngineContext
-├── utils.ts                        # Utilities (slugify, parseJson, etc.)
+├── constants.ts                    # Centralized constants (token budgets, notice durations)
+├── prompts.ts                      # Prompt barrel (8 languages)
 ├── texts.ts                        # i18n texts (barrel, 8 languages)
-├── llm-client.ts                   # LLM clients
-├── llm-client-wrapper.ts           # Advanced settings injection
+├── llm-client.ts                   # LLM clients (Anthropic, AnthropicCompat, OpenAICompat)
+├── llm-client-wrapper.ts           # Advanced settings injection wrapper
 ├── wiki/                           # Wiki engine
 │   ├── wiki-engine.ts              # Orchestrator
-│   ├── query-engine.ts             # Conversational query
+│   ├── query-engine.ts             # Conversational query (streaming + thinking UI)
 │   ├── source-analyzer.ts          # Iterative batch extraction
 │   ├── page-factory.ts             # Entity/concept CRUD + merge
 │   ├── conversation-ingest.ts      # Chat → wiki knowledge
@@ -96,16 +97,23 @@ src/
 │   ├── system-prompts.ts           # Language directive + labels
 │   ├── lint/                       # Lint subsystem
 │   │   ├── controller.ts           # Lint orchestration
-│   │   ├── fixer.ts                # Fix logic (LintFixer class)
 │   │   ├── fix-runners.ts          # Batch fix execution helpers
 │   │   ├── scanners.ts             # Scanners (dead links, orphans, aliases, quote grounding)
 │   │   ├── duplicate-detection.ts  # Programmatic candidate generation
 │   │   ├── report-builder.ts       # Pure-function report markdown builder
 │   │   ├── types.ts                # LintContext, LintPhaseContext, findings
+│   │   ├── fill-empty-page.ts      # Empty page fill logic
+│   │   ├── fix-dead-link.ts        # Dead link fix logic
+│   │   ├── fix-polluted-page.ts    # Polluted sources fix
+│   │   ├── link-orphan.ts          # Orphan page linking
+│   │   ├── merge-duplicates.ts     # Duplicate page merge
+│   │   ├── delete-empty-stubs.ts   # Empty stub deletion
+│   │   ├── get-existing-pages.ts   # Wiki page index reader
+│   │   ├── utils.ts                # Shared lint helpers
 │   │   └── phases/
 │   │       ├── preparation.ts      # Page read, link fix, sources normalize
 │   │       └── programmatic.ts     # Fast programmatic scanners
-│   └── prompts/                    # LLM prompt templates
+│   └── prompts/                    # LLM prompt templates (ingestion, generation, merge, fixes, lint, conversation)
 ├── schema/                         # Schema co-evolution
 │   ├── manager.ts                  # SchemaManager (read/write schema config)
 │   ├── auto-maintain.ts            # File watcher, periodic lint, startup quick fixes
@@ -113,19 +121,29 @@ src/
 ├── ui/
 │   ├── settings.ts                 # Settings panel
 │   └── modals.ts                   # Lint/Ingest/Query modals
-├── core/                           # Pure function modules
+├── core/                           # Pure function modules (zero IO, fully testable)
+│   ├── i18n.ts                     # Type-safe i18n accessor
+│   ├── slug.ts                     # Slug computation + alias filtering
+│   ├── json.ts                     # JSON response parsing + repair
+│   ├── frontmatter.ts              # Frontmatter parse/merge/constraints
+│   ├── tag-vocab.ts                # Active tag vocabulary helpers
+│   ├── index-search.ts             # Index parsing + local keyword match
+│   ├── rate-limit.ts               # Rate-limit detection + notice formatting
+│   ├── report.ts                   # Report truncation + heading nesting
+│   ├── arrays.ts                   # Array coercion + source tag extraction
+│   ├── markdown.ts                 # Markdown cleanup + thinking block extraction/encoding
 │   ├── sources-normalizer.ts       # Sources field normalization
 │   ├── truncation-retry.ts         # Token truncation retry policy
 │   ├── dead-link-detector.ts       # Dead link identification
 │   ├── orphan-matcher.ts           # Orphan page matching
-│   ├── prompt-builders.ts          # Prompt template builders
+│   ├── prompt-builders.ts          # Prompt template builders + path normalization
 │   ├── batch-limits.ts             # Adaptive batch sizing
 │   ├── batch-merger.ts             # Multi-batch result merging
 │   ├── convergence-detector.ts     # Early-stop on low-yield batches
-│   ├── sse-parser.ts               # SSE event parser
+│   ├── sse-parser.ts               # SSE event parser (anthropic + openai formats)
 │   ├── token-cap.ts                # max_tokens cap helper
 │   └── conflict-resolver.ts        # Conflict detection
-└── __tests__/                      # Unit tests (vitest, 728 tests)
+└── __tests__/                      # Unit tests (vitest, 771 tests)
 ```
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ src/
 ├── types.ts             # Shared types + EngineContext
 ├── constants.ts         # Centralized constants (token budgets, notice durations, WIKI_SUBFOLDERS)
 ├── texts.ts             # i18n texts (barrel, 8 languages)
+├── prompts.ts           # Prompt barrel (8 languages)
 ├── llm-client.ts        # LLM clients (Anthropic via requestUrl, OpenAI-compatible)
 ├── llm-client-wrapper.ts # Advanced settings injection wrapper
 ├── core/                # Pure function modules (zero IO, fully testable)
@@ -65,7 +66,7 @@ src/
 │   ├── rate-limit.ts           # Rate-limit detection + notice formatting
 │   ├── report.ts               # Report truncation + heading nesting
 │   ├── arrays.ts               # Array coercion + source tag extraction
-│   ├── markdown.ts             # Markdown response cleanup
+│   ├── markdown.ts             # Markdown cleanup + thinking block extraction/encoding
 │   ├── conflict-resolver.ts    # Conflict detection
 │   ├── dead-link-detector.ts   # Dead link identification
 │   ├── orphan-matcher.ts       # Orphan page matching
@@ -79,7 +80,7 @@ src/
 │   └── convergence-detector.ts # Early-stop on low-yield batches
 ├── wiki/                # Wiki engine modules
 │   ├── wiki-engine.ts   # Orchestrator (ingest, lint, log)
-│   ├── query-engine.ts  # Conversational query with streaming
+│   ├── query-engine.ts  # Conversational query with streaming + thinking UI
 │   ├── source-analyzer.ts # Iterative batch extraction
 │   ├── page-factory.ts  # Entity/concept CRUD + merge
 │   ├── conversation-ingest.ts # Chat → wiki knowledge

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -18,12 +18,13 @@
 
 ## 📑 Contents
 
-- [💡 Über LLM Wiki](#-Über-llm-wiki)
-- [💡 Über LLM Wiki](#-Über-llm-wiki)
+- [💡 Über LLM Wiki](#-über-llm-wiki)
+- [⚡ Warum Obsidian + LLM-Wiki?](#-warum-obsidian--llm-wiki)
+- [🚀 Schnellstart](#-schnellstart)
   - [📦 Installation](#-installation)
-  - [🔄 Plugin aktualisieren](#-plugin-aktualisieren)
-  - [🔑 LLM Provider konfigurieren](#-llm-provider-konfigurieren)
-  - [🎮 Nutzung](#-nutzung)
+  - [🔄 Aktualisierung](#-aktualisierung)
+  - [🔑 LLM-Provider konfigurieren](#-llm-provider-konfigurieren)
+  - [🎮 Verwendung](#-verwendung)
   - [⚠️ Upgrade von einer älteren Version?](#️-upgrade-von-einer-älteren-version)
 - [⚡ Was ist neu in v1.20.0](#-was-ist-neu-in-v1200)
 - [✨ Funktionen](#-funktionen)
@@ -64,6 +65,100 @@ Notizen schreiben. KI organisiert. Fragen stellen. Das ist alles.
 **📚 Keine Bibliotheksarbeit mehr.** Keine Bewertung des Seitenwerts. Keine Pflege von Querverweisen. Keine Angst vor veraltetem Content. Notizen in `sources/` ablegen — der LLM liest, extrahiert, schreibt, verlinkt und markiert Widersprüche, während Sie im Flow bleiben.
 
 **🤖 Kein weiterer Chatbot.** ChatGPT kennt das Internet. LLM Wiki kennt *Sie* — genauer: das, was Sie ihm beigebracht haben. Jede Antwort enthält `[[wiki-links]]` zurück in den Knowledge Graph. Jede Antwort ist ein Wegweiser, kein Dead End.
+
+---
+
+## ⚡ Warum Obsidian + LLM-Wiki?
+
+Obsidian ist brillant im vernetzten Denken. Aber das Problem: Sie selbst müssen alle Verbindungen herstellen.
+
+LLM-Wiki dreht das um. Statt dass Sie den Graphen von Hand aufbauen, wächst die KI ihn mit Ihnen. Fügen Sie eine Notiz über ein neues Konzept hinzu — sie findet Zusammenhänge, die Sie übersehen hätten. Stellen Sie eine Frage — sie durchsucht Ihren eigenen Wissensgraphen und liefert Antworten mit Quellenbelegen.
+
+- **🔗 Ihr Graph View wird lebendig.** Neue Notizen stehen nicht einfach nur da — sie sprießen Verbindungen zu Entities, Konzepten und Quellen. Der Graph wächst organisch, und das Plugin pflegt ihn: erkennt Duplikate, repariert tote Links, überbrückt Sprachen mit Aliases.
+- **💬 Ihre Notizen lernen, mit Ihnen zu sprechen.** Suche wird zum Gespräch. „Was habe ich über X geschrieben?" wird zum Dialog mit Streaming-Antworten und `[[wiki-links]]` als Wegmarken. Jede Antwort ist ein Pfad tiefer in Ihr eigenes Wissen.
+- **🧠 Obsidian wird zum Denkpartner.** Es hört auf, eine Ablage für Notizen zu sein, und wird zu etwas, das Ihnen beim *Denken* hilft — verborgene Zusammenhänge aufdeckt, Widersprüche markiert, sich an das erinnert, was Sie vergessen hatten.
+
+---
+
+## 🚀 Schnellstart
+
+### 📦 Installation
+
+**🌟 Empfohlen — Obsidian Community Plugin Market:**
+
+1. Gehe in Obsidian zu **Einstellungen → Community-Plugins**
+2. Klicke auf **Durchsuchen** und suche nach "Karpathy LLM Wiki"
+3. Klicke auf **Installieren**, dann **Aktivieren**
+
+**🌐 Oder über die Community Plugin Website —** besuche [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki) und klicke auf **Zu Obsidian hinzufügen**, um direkt zu installieren.
+
+**⚙️ Manuell (Alternative):**
+
+1. Lade `main.js`, `manifest.json`, `styles.css` von [Releases](https://github.com/green-dalii/obsidian-llm-wiki/releases) herunter
+2. Gehe in Obsidian zu Einstellungen → Community-Plugins. Auf dem Tab **Installierte Plugins** klicke auf das Ordnersymbol, um das Plugin-Verzeichnis zu öffnen
+3. Erstelle einen Ordner namens `karpathywiki` und lege die drei Dateien hinein
+4. Zurück in Obsidian klicke auf das Aktualisierungssymbol — **Karpathy LLM Wiki** erscheint unter Installierte Plugins
+5. Schalte es ein, um es zu aktivieren
+
+**🔨 Entwicklung:** `git clone`, `pnpm install`, `pnpm build`
+
+### 🔄 Aktualisierung
+
+Dieses Projekt entwickelt sich rasch — neue Funktionen, Fehlerbehebungen und Verbesserungen werden häufig veröffentlicht. Wir empfehlen, auf dem aktuellen Stand zu bleiben:
+
+**Option A — Manuelle Aktualisierung (empfohlen):**
+1. Gehe zu **Einstellungen → Community-Plugins**
+2. Klicke auf **Nach Updates suchen**
+3. Finde **Karpathy LLM Wiki** in der Liste und klicke auf **Aktualisieren**
+
+**Option B — Automatische Aktualisierung aktivieren:**
+1. Gehe zu **Einstellungen → Community-Plugins**
+2. Schalte **Automatisch nach Plugin-Updates suchen** ein
+3. Neue Versionen werden automatisch erkannt; aktualisieren Sie nach Bedarf manuell
+
+> 💡 **Warum aktualisieren?** Jedes Release kann neue Funktionen, Leistungsverbesserungen und wichtige Fehlerbehebungen enthalten.
+
+### 🔑 LLM-Provider konfigurieren
+
+1. Öffne Einstellungen → Karpathy LLM Wiki
+2. Wähle einen Provider aus dem Dropdown (Anthropic, Anthropic Compatible, Google Gemini, OpenAI, DeepSeek, Kimi, GLM, MiniMax, LM Studio, Ollama, OpenRouter oder Custom)
+3. Gib deinen API-Key ein (für Ollama nicht erforderlich)
+4. Klicke auf **Fetch Models**, um die Modellliste zu befüllen, oder gib einen Modellnamen manuell ein
+5. Klicke auf **Test Connection**, dann **Save Settings**
+
+**🦙 Ollama (lokal, kein API-Key):** Installiere [Ollama](https://ollama.com), pulle ein Modell (`ollama pull gemma4` oder `ollama pull qwen3.5:27b`), wähle "Ollama (Local)" im Provider-Dropdown.
+
+**🎛️ LM Studio (lokal, kein API-Key):** Installiere [LM Studio](https://lmstudio.ai), starte den lokalen Server (Standard `http://localhost:1234/v1`), wähle "LM Studio (Local)" im Provider-Dropdown.
+
+### 🎮 Verwendung
+
+| Methode | Anleitung |
+|---------|-----------|
+| **📥 Einzelne Quelle aufnehmen** | `Cmd+P` → "Ingest single source" — wähle eine Note, um Entities und Concepts zu extrahieren |
+| **📂 Aus Ordner aufnehmen** | `Cmd+P` → "Ingest from folder" — wähle einen Ordner, um Wiki im Batch zu generieren |
+| **🔍 Wiki anfragen** | `Cmd+P` → "Query wiki" — stelle Fragen und erhalte Streaming-Antworten |
+| **🛠️ Wiki prüfen** | `Cmd+P` → "Lint wiki" — Health Scan: Duplikate, tote Links, leere Seiten, Orphans |
+| **📋 Index neu generieren** | `Cmd+P` → "Regenerate index" — erstelle `wiki/index.md` neu |
+| **💡 Schema-Aktualisierungen vorschlagen** | `Cmd+P` → "Suggest schema updates" — LLM schlägt Schema-Verbesserungen vor |
+| **🎯 Ein-Klick-Aufnahme** | Klicke auf das Seitenleisten-Symbol oder `Cmd+P` → "Ingest current file" |
+
+### ⚠️ Upgrade von einer älteren Version?
+
+**Dieses Release ist vollständig abwärtskompatibel.** Keine Breaking Changes seit v1.0.0.
+
+**Bei einem Upgrade von einer Version vor v1.16.0**, führe einmal **Lint Wiki** aus, um historische Probleme automatisch zu beheben.
+
+**Für Wikis, die über viele Versionen aufgebaut wurden:**
+
+**1️⃣ Index neu aufbauen** — `Cmd+P` → "Regenerate index"
+
+**2️⃣ Lint Wiki ausführen** — `Cmd+P` → "Lint wiki" — Scannt auf fehlende Aliases, Duplikate, tote Links, Orphans
+
+**3️⃣ Smart Fix All verwenden** — Ein-Klick-Reparatur im Lint-Bericht
+
+**4️⃣ Parallele Seitengenerierung aktivieren** — Einstellungen → Page Generation Concurrency: 3, Batch Delay: 300ms
+
+**5️⃣ Aktuelle Einstellungen prüfen** — Wiki Output Language, Extraction Granularity, Auto-Maintenance
 
 ---
 

--- a/docs/README_ES.md
+++ b/docs/README_ES.md
@@ -19,12 +19,13 @@
 ## 📑 Contents
 
 - [💡 ¿Qué es LLM-Wiki?](#-qué-es-llm-wiki)
-- [💡 ¿Qué es LLM-Wiki?](#-qué-es-llm-wiki)
+- [⚡ ¿Por qué Obsidian + LLM-Wiki?](#-por-qué-obsidian--llm-wiki)
+- [🚀 Inicio rápido](#-inicio-rápido)
   - [📦 Instalación](#-instalación)
-  - [🔄 Actualizar el plugin](#-actualizar-el-plugin)
-  - [🔑 Configurar un Provider de LLM](#-configurar-un-provider-de-llm)
+  - [🔄 Actualización](#-actualización)
+  - [🔑 Configurar un proveedor LLM](#-configurar-un-proveedor-llm)
   - [🎮 Uso](#-uso)
-  - [⚠️ Actualizando desde una Versión Anterior](#️-actualizando-desde-una-versión-anterior)
+  - [⚠️ ¿Actualizar desde una versión anterior?](#️-actualizar-desde-una-versión-anterior)
 - [⚡ Novedades de la v1.20.0](#-novedades-de-la-v1200)
 - [✨ Características](#-características)
   - [📊 Calidad del Conocimiento](#-calidad-del-conocimiento)
@@ -57,6 +58,90 @@ Escribe. La IA organiza. Pregunta. Así de simple.
 **📚 No necesitas ser el bibliotecario.** No decidir qué merece página. No mantener enlaces cruzados. No verificar si algo está desactualizado. Deposita notas en `sources/` y el LLM lee, extrae, escribe, enlaza y señala contradicciones — mientras tú mantienes el flujo.
 
 **🤖 No es un chatbot más.** ChatGPT conoce internet. LLM-Wiki te conoce *a ti* — o más bien, lo que le has enseñado. Cada respuesta incluye `[[wiki-links]]` de regreso a tu grafo de conocimiento. Cada respuesta es un punto de partida, no un callejón sin salida.
+
+---
+
+## ⚡ ¿Por qué Obsidian + LLM-Wiki?
+
+Obsidian es brillante en el pensamiento conectado. Pero hay un inconveniente: eres tú quien hace todas las conexiones.
+
+LLM-Wiki invierte eso. En lugar de que construyas el grafo a mano, la IA lo cultiva contigo. Agrega una nota sobre un nuevo concepto — encuentra las conexiones que habrías pasado por alto. Haz una pregunta — recorre tu propio grafo de conocimiento y trae respuestas con citas.
+
+- **🔗 Tu Graph View cobra vida.** Las nuevas notas no simplemente están ahí — brotan enlaces a entidades, conceptos y fuentes. El grafo crece orgánicamente, y el plugin lo mantiene: detectando duplicados, corrigiendo enlaces rotos, poniendo puentes entre idiomas mediante aliases.
+- **💬 Tus notas aprenden a responderte.** La búsqueda se convierte en conversación. "¿Qué escribí sobre X?" se transforma en un diálogo, con respuestas en streaming y `[[wiki-links]]` como migas de pan. Cada respuesta es un camino más profundo en tu propio conocimiento.
+- **🧠 Obsidian se convierte en un compañero de pensamiento.** Deja de ser un archivador de notas y pasa a ser algo que te ayuda a *pensar* — revelando conexiones ocultas, señalando contradicciones, recordando lo que habías olvidado que sabías.
+
+---
+
+## 🚀 Inicio rápido
+
+### 📦 Instalación
+
+**🌟 Recomendado — Mercado de plugins comunitarios de Obsidian:**
+1. En Obsidian, ve a **Configuración → Plugins comunitarios**
+2. Haz clic en **Examinar** y busca "Karpathy LLM Wiki"
+3. Haz clic en **Instalar**, luego **Habilitar**
+
+**🌐 O desde el sitio web de plugins comunitarios —** visita [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki) y haz clic en **Add to Obsidian**.
+
+**⚙️ Manual (alternativa):**
+1. Descarga `main.js`, `manifest.json`, `styles.css` desde [Releases](https://github.com/green-dalii/obsidian-llm-wiki/releases)
+2. En Obsidian, ve a Configuración → Plugins comunitarios. Haz clic en el icono de carpeta para abrir el directorio de plugins
+3. Crea una carpeta llamada `karpathywiki`, coloca los tres archivos dentro
+4. De vuelta en Obsidian, haz clic en el icono de refrescar — **Karpathy LLM Wiki** aparecerá
+5. Actívalo para habilitarlo
+
+**🔨 Desarrollo:** `git clone`, `pnpm install`, `pnpm build`.
+
+### 🔄 Actualización
+
+Este proyecto evoluciona rápidamente. Recomendamos mantenerse actualizado:
+
+**Opción A — Actualización manual (recomendada):**
+1. Ve a **Configuración → Plugins comunitarios**
+2. Haz clic en **Buscar actualizaciones**
+3. Encuentra **Karpathy LLM Wiki** y haz clic en **Actualizar**
+
+**Opción B — Habilitar actualización automática:**
+1. Ve a **Configuración → Plugins comunitarios**
+2. Activa **Comprobar automáticamente actualizaciones de plugins**
+
+> 💡 **¿Por qué mantenerse actualizado?** Cada versión puede incluir nuevas funciones, mejoras de rendimiento y correcciones de errores importantes.
+
+### 🔑 Configurar un proveedor LLM
+
+1. Abre Configuración → Karpathy LLM Wiki
+2. Elige un proveedor del menú desplegable
+3. Ingresa tu clave API (no necesaria para Ollama)
+4. Haz clic en **Fetch Models**, o escribe un nombre de modelo manualmente
+5. Haz clic en **Test Connection**, luego **Guardar configuración**
+
+**🦙 Ollama (local):** Instala [Ollama](https://ollama.com), descarga un modelo, selecciona "Ollama (Local)".
+
+**🎛️ LM Studio (local):** Instala [LM Studio](https://lmstudio.ai), inicia el servidor local, selecciona "LM Studio (Local)".
+
+### 🎮 Uso
+
+| Método | Cómo |
+|--------|------|
+| **📥 Ingestar fuente individual** | `Cmd+P` → "Ingestar fuente individual" |
+| **📂 Ingestar desde carpeta** | `Cmd+P` → "Ingestar desde carpeta" |
+| **🔍 Consultar wiki** | `Cmd+P` → "Consultar wiki" |
+| **🛠️ Verificar wiki** | `Cmd+P` → "Verificar wiki" |
+| **📋 Regenerar índice** | `Cmd+P` → "Regenerar índice" |
+| **💡 Sugerir actualizaciones del esquema** | `Cmd+P` → "Sugerir actualizaciones del esquema" |
+| **🎯 Ingestión con un clic** | Icono de la barra lateral o `Cmd+P` → "Ingestar archivo actual" |
+
+### ⚠️ ¿Actualizar desde una versión anterior?
+
+**Esta versión es completamente retrocompatible.** Sin cambios incompatibles desde v1.0.0.
+
+**Para wikis construidos con múltiples versiones:**
+1️⃣ Reconstruye tu índice — "Regenerar índice"
+2️⃣ Ejecuta Verificar wiki — escanea problemas
+3️⃣ Usa Smart Fix All — reparación con un clic
+4️⃣ Habilita generación de páginas paralela — Concurrencia: 3, Retraso: 300ms
+5️⃣ Revisa la configuración — Idioma, Granularidad, Auto-Mantenimiento
 
 ---
 

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -19,12 +19,13 @@
 ## 📑 Contents
 
 - [💡 Présentation](#-présentation)
-- [💡 Présentation](#-présentation)
+- [⚡ Pourquoi Obsidian + LLM-Wiki ?](#-pourquoi-obsidian--llm-wiki-)
+- [🚀 Démarrage rapide](#-démarrage-rapide)
   - [📦 Installation](#-installation)
-  - [🔄 Mettre à jour le plugin](#-mettre-à-jour-le-plugin)
-  - [🔑 Configuration d'un Provider LLM](#-configuration-dun-provider-llm)
+  - [🔄 Mise à jour](#-mise-à-jour)
+  - [🔑 Configurer un fournisseur LLM](#-configurer-un-fournisseur-llm)
   - [🎮 Utilisation](#-utilisation)
-  - [⚠️ Mise à niveau depuis une version antérieure ?](#️-mise-à-niveau-depuis-une-version-antérieure-)
+  - [⚠️ Mise à niveau depuis une ancienne version ?](#️-mise-à-niveau-depuis-une-ancienne-version-)
 - [⚡ Nouveautés de la v1.20.0](#-nouveautés-de-la-v1200)
 - [✨ Fonctionnalités](#-fonctionnalités)
   - [📊 Qualité des connaissances](#-qualité-des-connaissances)
@@ -57,6 +58,90 @@ Vous écrivez. L'IA organise. Vous interrogez. Rien de plus.
 **📚 Libérez-vous du rôle de bibliothécaire.** Plus besoin de décider ce qui mérite une page. Plus besoin de maintenir les liens croisés. Plus besoin de vérifier l'obsolescence. Déposez vos notes dans `sources/` : le LLM lit, extrait, rédige, relie et signale les contradictions — pendant que vous restez concentré sur l'essentiel.
 
 **🤖 Ce n'est pas un chatbot de plus.** ChatGPT connaît Internet. LLM-Wiki connaît *vous* — ou plutôt, ce que vous lui avez enseigné. Chaque réponse intègre des `[[Wiki-links]]` vers votre graphe de connaissances. Chaque réponse est un point de départ, jamais une impasse.
+
+---
+
+## ⚡ Pourquoi Obsidian + LLM-Wiki ?
+
+Obsidian excelle dans la pensee liee. Mais il y a un hic : c'est vous qui faites tous les liens.
+
+LLM-Wiki inverse la donne. Au lieu de construire le graphe a la main, l'IA le developpe avec vous. Ajoutez une note sur un nouveau concept — elle trouve les connexions que vous auriez manquees. Posez une question — elle parcourt votre propre graphe de connaissances et revient avec des reponses citees.
+
+- **🔗 Votre Graph View prend vie.** Les nouvelles notes ne restent pas inertes — elles germent des liens vers des entites, des concepts et des sources. Le graphe grandit de maniere organique, et le plugin l'entretient : detection des doublons, correction des liens morts, ponts entre langues via les aliases.
+- **💬 Vos notes apprennent a vous repondre.** La recherche devient conversation. « Qu'ai-je ecrit sur X ? » devient un dialogue, avec des reponses en streaming et des `[[wiki-links]]` comme fil d'Ariane. Chaque reponse est un chemin plus profond dans vos propres connaissances.
+- **🧠 Obsidian devient un partenaire de reflexion.** Il cesse d'etre un simple classeur a notes et devient un outil qui vous aide a *penser* — revelant des connexions cachees, signalant les contradictions, se rappelant ce que vous aviez oublie.
+
+---
+
+## 🚀 Démarrage rapide
+
+### 📦 Installation
+
+**🌟 Recommandé — Marché des plugins communautaires Obsidian :**
+1. Dans Obsidian, allez dans **Paramètres → Plugins communautaires**
+2. Cliquez sur **Parcourir** et recherchez « Karpathy LLM Wiki »
+3. Cliquez sur **Installer**, puis **Activer**
+
+**🌐 Ou depuis le site des plugins communautaires —** visitez [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki) et cliquez sur **Add to Obsidian**.
+
+**⚙️ Manuel (alternative) :**
+1. Téléchargez `main.js`, `manifest.json`, `styles.css` depuis les [Releases](https://github.com/green-dalii/obsidian-llm-wiki/releases)
+2. Dans Obsidian, allez dans Paramètres → Plugins communautaires. Cliquez sur l'icône de dossier pour ouvrir le répertoire des plugins
+3. Créez un dossier nommé `karpathywiki`, déposez les trois fichiers à l'intérieur
+4. De retour dans Obsidian, cliquez sur l'icône de rafraîchissement — **Karpathy LLM Wiki** apparaîtra
+5. Activez-le pour l'activer
+
+**🔨 Développement :** `git clone`, `pnpm install`, `pnpm build`.
+
+### 🔄 Mise à jour
+
+Ce projet évolue rapidement. Nous vous recommandons de rester à jour :
+
+**Option A — Mise à jour manuelle (recommandée) :**
+1. Allez dans **Paramètres → Plugins communautaires**
+2. Cliquez sur **Vérifier les mises à jour**
+3. Trouvez **Karpathy LLM Wiki** et cliquez sur **Mettre à jour**
+
+**Option B — Activer la mise à jour automatique :**
+1. Allez dans **Paramètres → Plugins communautaires**
+2. Activez **Vérifier automatiquement les mises à jour des plugins**
+
+> 💡 **Pourquoi rester à jour ?** Chaque version peut inclure de nouvelles fonctionnalités, des améliorations de performance et des corrections de bugs importantes.
+
+### 🔑 Configurer un fournisseur LLM
+
+1. Ouvrez Paramètres → Karpathy LLM Wiki
+2. Choisissez un fournisseur dans le menu déroulant
+3. Entrez votre clé API (non nécessaire pour Ollama)
+4. Cliquez sur **Fetch Models**, ou tapez un nom de modèle manuellement
+5. Cliquez sur **Test Connection**, puis **Enregistrer les paramètres**
+
+**🦙 Ollama (local) :** Installez [Ollama](https://ollama.com), téléchargez un modèle, sélectionnez « Ollama (Local) ».
+
+**🎛️ LM Studio (local) :** Installez [LM Studio](https://lmstudio.ai), démarrez le serveur local, sélectionnez « LM Studio (Local) ».
+
+### 🎮 Utilisation
+
+| Méthode | Comment |
+|---------|---------|
+| **📥 Ingestion d'une source unique** | `Cmd+P` → « Importer une source unique » |
+| **📂 Ingestion depuis un dossier** | `Cmd+P` → « Importer depuis un dossier » |
+| **🔍 Interroger le wiki** | `Cmd+P` → « Interroger le wiki » |
+| **🛠️ Vérifier le wiki** | `Cmd+P` → « Vérifier le wiki » |
+| **📋 Régénérer l'index** | `Cmd+P` → « Régénérer l'index » |
+| **💡 Suggérer des mises à jour du schéma** | `Cmd+P` → « Suggérer des mises à jour du schéma » |
+| **🎯 Ingestion en un clic** | Icône de la barre latérale ou `Cmd+P` → « Ingérer le fichier actuel » |
+
+### ⚠️ Mise à niveau depuis une ancienne version ?
+
+**Cette version est entièrement rétrocompatible.** Aucun changement cassant depuis la v1.0.0.
+
+**Pour les wikis construits sur plusieurs versions :**
+1️⃣ Reconstruisez votre index — « Régénérer l'index »
+2️⃣ Lancez Vérifier le wiki — scanne les problèmes
+3️⃣ Utilisez Smart Fix All — réparation en un clic
+4️⃣ Activez la génération de pages parallèle — Concurrence : 3, Délai : 300ms
+5️⃣ Vérifiez les paramètres — Langue, Granularité, Auto-Maintenance
 
 ---
 

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -19,13 +19,14 @@
 ## 📑 Contents
 
 - [💡 LLM-Wikiとは？](#-llm-wikiとは)
-- [💡 LLM-Wikiとは？](#-llm-wikiとは)
+- [⚡ なぜ Obsidian + LLM-Wiki？](#-なぜ-obsidian--llm-wiki)
+- [🚀 クイックスタート](#-クイックスタート)
   - [📦 インストール](#-インストール)
-  - [🔄 プラグインの更新](#-プラグインの更新)
-  - [🔑 LLM Providerを設定](#-llm-providerを設定)
-  - [🎮 使用方法](#-使用方法)
-  - [⚠️ 旧バージョンからアップグレードする場合](#️-旧バージョンからアップグレードする場合)
-- [⚡ What's New in v1.20.0](#-whats-new-in-v1200)
+  - [🔄 アップデート](#-アップデート)
+  - [🔑 LLMプロバイダーの設定](#-llmプロバイダーの設定)
+  - [🎮 使い方](#-使い方)
+  - [⚠️ 旧バージョンからのアップグレード](#️-旧バージョンからのアップグレード)
+- [⚡ v1.20.0 更新のポイント](#-v1200-更新のポイント)
 - [✨ 特徴](#-特徴)
   - [📊 Knowledge Quality](#-knowledge-quality)
   - [🛠️ Maintenance](#️-maintenance)
@@ -60,7 +61,101 @@
 
 ---
 
-## ⚡ What's New in v1.20.0
+## ⚡ なぜ Obsidian + LLM-Wiki？
+
+Obsidianはリンク思考において卓越しています。しかし、すべてのリンクを自分で作らなければならないという課題があります。
+
+LLM-Wikiはその構造を反転させます。あなたが手作業でグラフを構築する代わりに、AIが一緒にグラフを育ててくれます。新しい概念についてノートを追加すれば、見落としていたつながりを見つけてくれます。質問をすれば、あなた自身の知識グラフを辿り、引用付きの回答を返してくれます。
+
+- **🔗 グラフビューが動き出す。** 新しいノートはただ置かれるだけでなく、Entity、Concept、ソースへのリンクを芽吹かせます。グラフは有機的に成長し、プラグインがそれを維持します——重複の検出、リンク切れの修正、エイリアスによる言語間の橋渡し。
+- **💬 ノートが会話できるように。** 検索が対話になります。「Xについて何を書いた？」がダイアログになり、ストリーミングレスポンスと`[[wiki-links]]`がパンくずリストとなります。すべての回答は、あなた自身の知識へと深く踏み込む道です。
+- **🧠 Obsidianが思考パートナーに。** ノートの保管庫から、あなたが*考える*のを助けるものへと変わります——隠れたつながりを浮き彫りにし、矛盾を指摘し、自分が忘れていたことを思い出させてくれます。
+
+---
+
+## 🚀 クイックスタート
+
+### 📦 インストール
+
+**🌟 推奨 — Obsidianコミュニティプラグインマーケット：**
+
+1. Obsidianで **設定 → コミュニティプラグイン** を開く
+2. **ブラウズ** をクリックして「Karpathy LLM Wiki」を検索
+3. **インストール** をクリックし、**有効化** する
+
+**🌐 コミュニティプラグインのWebサイトから —** [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki) にアクセスし、**Obsidianに追加** をクリックして直接インストールできます。
+
+**⚙️ 手動インストール（代替方法）：**
+
+1. [Releases](https://github.com/green-dalii/obsidian-llm-wiki/releases) から `main.js`、`manifest.json`、`styles.css` をダウンロード
+2. Obsidianで 設定 → コミュニティプラグイン を開く。**インストール済みプラグイン** タブでフォルダアイコンをクリックし、プラグインディレクトリを開く
+3. `karpathywiki` という名前のフォルダを作成し、3つのファイルを配置
+4. Obsidianに戻り、更新アイコンをクリック — **Karpathy LLM Wiki** がインストール済みプラグインに表示される
+5. トグルをオンにして有効化
+
+**🔨 開発用：** `git clone`、`pnpm install`、`pnpm build`
+
+### 🔄 アップデート
+
+本プロジェクトは急速に進化しており、新機能、バグ修正、改善が頻繁にリリースされます。最新の状態に保つことをお勧めします：
+
+**オプションA — 手動アップデート（推奨）：**
+1. **設定 → コミュニティプラグイン** を開く
+2. **更新を確認** をクリック
+3. **Karpathy LLM Wiki** を見つけ、**更新** をクリック
+
+**オプションB — 自動更新を有効にする：**
+1. **設定 → コミュニティプラグイン** を開く
+2. **プラグインの自動更新を確認** をオンにする
+3. 新しいバージョンが自動的に検出されます。都合の良いタイミングで手動で更新してください
+
+> 💡 **なぜ最新版を保つべき？** 各リリースには新機能、パフォーマンス改善、重要なバグ修正が含まれている場合があります。
+
+### 🔑 LLMプロバイダーの設定
+
+1. 設定 → Karpathy LLM Wiki を開く
+2. ドロップダウンからプロバイダーを選択（Anthropic、Anthropic Compatible、Google Gemini、OpenAI、DeepSeek、Kimi、GLM、MiniMax、LM Studio、Ollama、OpenRouter、またはカスタム）
+3. APIキーを入力（Ollamaは不要）
+4. **Fetch Models** をクリックしてモデルリストを取得するか、モデル名を手動入力
+5. **Test Connection** をクリックし、**Save Settings** を保存
+
+**🦙 Ollama（ローカル、APIキー不要）：** [Ollama](https://ollama.com) をインストールし、モデルをpull（`ollama pull gemma4` または `ollama pull qwen3.5:27b`）、プロバイダードロップダウンで「Ollama (Local)」を選択。
+
+**🎛️ LM Studio（ローカル、APIキー不要）：** [LM Studio](https://lmstudio.ai) をインストールし、ローカルサーバーを起動（デフォルト `http://localhost:1234/v1`）、プロバイダードロップダウンで「LM Studio (Local)」を選択。
+
+### 🎮 使い方
+
+| 方法 | 使い方 |
+|------|--------|
+| **📥 単一ソースの取り込み** | `Cmd+P` → "Ingest single source" — ノートを選択してEntityとConceptを抽出 |
+| **📂 フォルダーからの取り込み** | `Cmd+P` → "Ingest from folder" — フォルダを選択し、Wikiを一括生成 |
+| **🔍 Wikiに問い合わせ** | `Cmd+P` → "Query wiki" — 質問をし、ストリーミング回答を取得 |
+| **🛠️ WikiのLint** | `Cmd+P` → "Lint wiki" — 健康スキャン：重複、dead links、空ページ、孤立ページ |
+| **📋 インデックスの再生成** | `Cmd+P` → "Regenerate index" — `wiki/index.md` を再構築 |
+| **💡 スキーマ更新の提案** | `Cmd+P` → "Suggest schema updates" — LLMがスキーマの改善を提案 |
+| **🎯 ワンクリック取り込み** | サイドバーのアイコンをクリック、または `Cmd+P` → "Ingest current file" |
+
+### ⚠️ 旧バージョンからのアップグレード
+
+**本リリースは完全に後方互換性があります。** v1.0.0以降、破壊的変更はありません。
+
+**v1.16.0以前のバージョンからアップグレードする場合**、一度 **Lint Wiki** を実行して過去の問題を自動修正してください。
+
+**複数バージョンにわたって構築されたWikiの場合：**
+
+**1️⃣ インデックスを再構築** — `Cmd+P` → "Regenerate index"
+
+**2️⃣ Lint Wikiを実行** — `Cmd+P` → "Lint wiki" — 欠落alias、重複、dead links、孤立ページをスキャン
+
+**3️⃣ Smart Fix Allを使用** — Lintレポートでワンクリック修復
+
+**4️⃣ 並列ページ生成を有効化** — 設定 → Page Generation Concurrency: 3、Batch Delay: 300ms
+
+**5️⃣ 現在の設定を確認** — Wiki Output Language、Extraction Granularity、Auto-Maintenance
+
+---
+
+## ⚡ v1.20.0 更新のポイント
 
 v1.20.0は、LLMの思考/推論処理方法を再設計した**マイナーリリース**です。プラグインはデフォルトでプロバイダー固有の思考制御フィールドを送信しません——プロバイダーが独自の動作を決定します。思考コンテンツが表示された場合（DeepSeekのreasoningなど）、回答の上にChatGPT/Claude.aiスタイルの折りたたみ可能なパネルで表示されます。
 

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -19,12 +19,13 @@
 ## 📑 Contents
 
 - [💡 LLM-Wiki란?](#-llm-wiki란)
-- [💡 LLM-Wiki란?](#-llm-wiki란)
+- [⚡ 왜 Obsidian + LLM-Wiki인가?](#-왜-obsidian--llm-wiki인가)
+- [🚀 빠른 시작](#-빠른-시작)
   - [📦 설치](#-설치)
-  - [🔄 플러그인 업데이트](#-플러그인-업데이트)
-  - [🔑 LLM Provider 설정](#-llm-provider-설정)
+  - [🔄 업데이트](#-업데이트)
+  - [🔑 LLM 프로바이더 설정](#-llm-프로바이더-설정)
   - [🎮 사용법](#-사용법)
-  - [⚠️ 이전 버전에서 업그레이드하시나요?](#️-이전-버전에서-업그레이드하시나요)
+  - [⚠️ 이전 버전에서 업그레이드?](#️-이전-버전에서-업그레이드)
 - [⚡ v1.20.0 업데이트 하이라이트](#-v1200-업데이트-하이라이트)
 - [✨ 주요 기능](#-주요-기능)
   - [📊 지식 품질](#-지식-품질)
@@ -57,6 +58,100 @@
 **📚 당신은 더 이상 사서가 아닙니다.** 어떤 내용을 페이지로 만들지 결정할 필요도, 교차 링크를 유지할 필요도, 정보가 오래되었는지 걱정할 필요도 없습니다. 노트를 `sources/`에 넣으면 LLM이 읽고, 추출하고, 작성하고, 연결하며, 심지어 모순까지 표시합니다 — 당신은 몰입을 유지하면서 작업을 계속합니다.
 
 **🤖 그리고 이것은 또 다른 챗봇이 아닙니다.** ChatGPT는 인터넷을 알고 있습니다. LLM-Wiki는 *당신*을 압니다 — 정확히 말하자면 당신이 가르친 내용을 압니다. 모든 답변은 `[[wiki-links]]`를 통해 지식 그래프로 연결됩니다. 모든 응답은 끝이 아닌 탐색의 시작점입니다.
+
+---
+
+## ⚡ 왜 Obsidian + LLM-Wiki인가?
+
+Obsidian은 연결된 사고에 탁월합니다. 하지만 한 가지 문제가 있습니다: 모든 연결을 직접 만들어야 한다는 점입니다.
+
+LLM-Wiki는 이 구조를 뒤집습니다. 직접 그래프를 수작업으로 만드는 대신, AI가 여러분과 함께 그래프를 키워줍니다. 새로운 개념에 대한 노트를 추가하면 놓쳤을 연결을 찾아주고, 질문을 던지면 여러분만의 지식 그래프를 탐색하여 인용과 함께 답변을 가져다줍니다.
+
+- **🔗 그래프 뷰가 살아납니다.** 새로운 노트는 단순히 저장되는 것이 아니라 Entity, 개념, 소스로의 링크를 뻗어냅니다. 그래프는 유기적으로 성장하고, 플러그인이 이를 관리합니다: 중복 감지, 데드 링크 수정, 에이リア스를 통한 언어 간 연결.
+- **💬 노트가 대화하기 시작합니다.** 검색이 대화가 됩니다. "X에 대해 무엇을 썼지?"가 스트리밍 응답과 `[[wiki-links]]`라는 빵조각과 함께 하나의 대화가 됩니다. 모든 답변은 여러분의 지식 속으로 더 깊이 들어가는 길입니다.
+- **🧠 Obsidian이 사고의 파트너가 됩니다.** 더 이상 노트의 창고가 아니라, 여러분이 *생각*하는 것을 돕는 존재가 됩니다. 숨겨진 연결을 발견하고, 모순을 표시하고, 잊고 있던 것을 기억해줍니다.
+
+---
+
+## 🚀 빠른 시작
+
+### 📦 설치
+
+**🌟 권장 — Obsidian 커뮤니티 플러그인 마켓:**
+
+1. Obsidian에서 **설정 → 커뮤니티 플러그인**으로 이동
+2. **찾아보기**를 클릭하고 "Karpathy LLM Wiki"를 검색
+3. **설치**를 클릭한 다음 **활성화**
+
+**🌐 커뮤니티 플러그인 웹사이트에서 —** [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki)에 방문하여 **Obsidian에 추가**를 클릭하면 직접 설치할 수 있습니다.
+
+**⚙️ 수동 설치 (대안):**
+
+1. [Releases](https://github.com/green-dalii/obsidian-llm-wiki/releases)에서 `main.js`, `manifest.json`, `styles.css`를 다운로드
+2. Obsidian에서 설정 → 커뮤니티 플러그인으로 이동. **설치된 플러그인** 탭에서 폴더 아이콘을 클릭하여 플러그인 디렉토리를 엽니다
+3. `karpathywiki`라는 이름의 폴더를 만들고 세 파일을 넣습니다
+4. Obsidian으로 돌아가 새로고침 아이콘을 클릭 — **Karpathy LLM Wiki**가 설치된 플러그인에 나타납니다
+5. 켜기 토글을 눌러 활성화
+
+**🔨 개발용:** `git clone`, `pnpm install`, `pnpm build`
+
+### 🔄 업데이트
+
+이 프로젝트는 빠르게 진화하며 새로운 기능, 버그 수정, 개선 사항이 자주 제공됩니다. 최신 상태를 유지하는 것을 권장합니다:
+
+**옵션 A — 수동 업데이트 (권장):**
+1. **설정 → 커뮤니티 플러그인**으로 이동
+2. **업데이트 확인** 클릭
+3. 목록에서 **Karpathy LLM Wiki**를 찾아 **업데이트** 클릭
+
+**옵션 B — 자동 업데이트 활성화:**
+1. **설정 → 커뮤니티 플러그인**으로 이동
+2. **플러그인 자동 업데이트 확인** 켜기
+3. 새 버전이 자동으로 감지됩니다. 편리한 때에 수동으로 업데이트하세요
+
+> 💡 **왜 업데이트를 유지해야 하나요?** 각 릴리즈에는 새로운 기능, 성능 개선, 중요한 버그 수정이 포함될 수 있습니다.
+
+### 🔑 LLM 프로바이더 설정
+
+1. 설정 → Karpathy LLM Wiki 열기
+2. 드롭다운에서 프로바이더 선택 (Anthropic, Anthropic Compatible, Google Gemini, OpenAI, DeepSeek, Kimi, GLM, MiniMax, LM Studio, Ollama, OpenRouter 또는 커스텀)
+3. API 키 입력 (Ollama는 불필요)
+4. **Fetch Models**를 클릭하여 모델 목록을 가져오거나 모델 이름을 수동 입력
+5. **Test Connection** 클릭 후 **Save Settings** 저장
+
+**🦙 Ollama (로컬, API 키 불필요):** [Ollama](https://ollama.com)를 설치하고 모델을 pull(`ollama pull gemma4` 또는 `ollama pull qwen3.5:27b`)한 다음 프로바이더 드롭다운에서 "Ollama (Local)"을 선택하세요.
+
+**🎛️ LM Studio (로컬, API 키 불필요):** [LM Studio](https://lmstudio.ai)를 설치하고 로컬 서버(기본 `http://localhost:1234/v1`)를 시작한 다음 프로바이더 드롭다운에서 "LM Studio (Local)"을 선택하세요.
+
+### 🎮 사용법
+
+| 방법 | 사용법 |
+|------|--------|
+| **📥 단일 소스 수집** | `Cmd+P` → "Ingest single source" — 노트를 선택하여 Entity와 Concept를 추출 |
+| **📂 폴더에서 수집** | `Cmd+P` → "Ingest from folder" — 폴더를 선택하여 Wiki를 일괄 생성 |
+| **🔍 위키 질의** | `Cmd+P` → "Query wiki" — 질문하고 스트리밍 답변을 받기 |
+| **🛠️ 위키 린트** | `Cmd+P` → "Lint wiki" — 상태 검사: 중복, dead link, 빈 페이지, 고아 페이지 |
+| **📋 인덱스 재생성** | `Cmd+P` → "Regenerate index" — `wiki/index.md`를 다시 빌드 |
+| **💡 스키마 업데이트 제안** | `Cmd+P` → "Suggest schema updates" — LLM이 스키마 개선을 제안 |
+| **🎯 원클릭 수집** | 사이드바 아이콘 클릭 또는 `Cmd+P` → "Ingest current file" |
+
+### ⚠️ 이전 버전에서 업그레이드?
+
+**이 릴리즈는 완전히 하위 호환됩니다.** v1.0.0 이후 파괴적 변경이 없습니다.
+
+**v1.16.0 이전 버전에서 업그레이드하는 경우**, 한 번 **Lint Wiki**를 실행하여 이전 문제를 자동으로 수정하세요.
+
+**여러 버전에 걸쳐 구축된 Wiki의 경우:**
+
+**1️⃣ 인덱스 재구축** — `Cmd+P` → "Regenerate index"
+
+**2️⃣ Lint Wiki 실행** — `Cmd+P` → "Lint wiki" — 누락된 alias, 중복, dead link, 고아 페이지 스캔
+
+**3️⃣ Smart Fix All 사용** — Lint 보고서에서 원클릭 수리
+
+**4️⃣ 병렬 페이지 생성 활성화** — 설정 → Page Generation Concurrency: 3, Batch Delay: 300ms
+
+**5️⃣ 현재 설정 확인** — Wiki Output Language, Extraction Granularity, Auto-Maintenance
 
 ---
 

--- a/docs/README_PT.md
+++ b/docs/README_PT.md
@@ -19,12 +19,13 @@
 ## 📑 Contents
 
 - [💡 O que é LLM-Wiki?](#-o-que-é-llm-wiki)
-- [💡 O que é LLM-Wiki?](#-o-que-é-llm-wiki)
+- [⚡ Por que Obsidian + LLM-Wiki?](#-por-que-obsidian--llm-wiki)
+- [🚀 Início rápido](#-início-rápido)
   - [📦 Instalação](#-instalação)
-  - [🔄 Atualizar o plugin](#-atualizar-o-plugin)
-  - [🔑 Configurar um LLM Provider](#-configurar-um-llm-provider)
+  - [🔄 Atualização](#-atualização)
+  - [🔑 Configurar um provedor LLM](#-configurar-um-provedor-llm)
   - [🎮 Uso](#-uso)
-  - [⚠️ Atualizando de uma Versão Anterior?](#️-atualizando-de-uma-versão-anterior)
+  - [⚠️ Atualizando de uma versão anterior?](#️-atualizando-de-uma-versão-anterior)
 - [⚡ Novidades da v1.20.0](#-novidades-da-v1200)
 - [✨ Funcionalidades](#-funcionalidades)
   - [📊 Qualidade do Conhecimento](#-qualidade-do-conhecimento)
@@ -57,6 +58,90 @@ Você escreve. A IA organiza. Você pergunta. Simples assim.
 **📚 Você não precisa ser o bibliotecário.** Não decidir o que merece uma página. Não manter links cruzados. Não questionar se algo está desatualizado. Coloque notas em `sources/` e o LLM lê, extrai, escreve, vincula e sinaliza contradições — enquanto você permanece no fluxo.
 
 **🤖 Não é apenas outro chatbot.** O ChatGPT conhece a internet. O LLM-Wiki conhece *você* — ou melhor, o que você lhe ensinou. Cada resposta inclui `[[wiki-links]]` de volta ao seu knowledge graph. Cada resposta é um ponto de partida, não um beco sem saída.
+
+---
+
+## ⚡ Por que Obsidian + LLM-Wiki?
+
+Obsidian é brilhante no pensamento conectado. Mas há um problema: quem faz todas as conexões é você.
+
+O LLM-Wiki inverte isso. Em vez de você construir o grafo manualmente, a IA o desenvolve junto com você. Adicione uma nota sobre um novo conceito — ela encontra as conexões que você perderia. Faça uma pergunta — ela percorre seu próprio grafo de conhecimento e retorna respostas com citações.
+
+- **🔗 Seu Graph View ganha vida.** Novas notas não ficam apenas paradas — elas germinam links para entidades, conceitos e fontes. O grafo cresce organicamente, e o plugin o mantém: detectando duplicatas, corrigindo links mortos, conectando idiomas por meio de aliases.
+- **💬 Suas notas aprendem a conversar.** A busca se torna conversa. "O que eu escrevi sobre X?" vira um diálogo, com respostas em streaming e `[[wiki-links]]` como migalhas de pão. Cada resposta é um caminho mais profundo em seu próprio conhecimento.
+- **🧠 Obsidian se torna um parceiro de pensamento.** Ele deixa de ser um armário de notas e passa a ser algo que ajuda você a *pensar* — revelando conexões ocultas, sinalizando contradições, lembrando o que você esqueceu que sabia.
+
+---
+
+## 🚀 Início rápido
+
+### 📦 Instalação
+
+**🌟 Recomendado — Mercado de plugins comunitários do Obsidian:**
+1. No Obsidian, vá em **Configurações → Plugins da comunidade**
+2. Clique em **Procurar** e pesquise por "Karpathy LLM Wiki"
+3. Clique em **Instalar**, depois **Ativar**
+
+**🌐 Ou pelo site de plugins comunitários —** visite [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki) e clique em **Add to Obsidian**.
+
+**⚙️ Manual (alternativa):**
+1. Baixe `main.js`, `manifest.json`, `styles.css` nas [Releases](https://github.com/green-dalii/obsidian-llm-wiki/releases)
+2. No Obsidian, vá em Configurações → Plugins da comunidade. Clique no ícone de pasta para abrir o diretório de plugins
+3. Crie uma pasta chamada `karpathywiki`, coloque os três arquivos dentro
+4. De volta ao Obsidian, clique no ícone de atualizar — **Karpathy LLM Wiki** aparecerá
+5. Ative-o para habilitar
+
+**🔨 Desenvolvimento:** `git clone`, `pnpm install`, `pnpm build`.
+
+### 🔄 Atualização
+
+Este projeto evolui rapidamente. Recomendamos manter-se atualizado:
+
+**Opção A — Atualização manual (recomendada):**
+1. Vá em **Configurações → Plugins da comunidade**
+2. Clique em **Verificar atualizações**
+3. Encontre **Karpathy LLM Wiki** e clique em **Atualizar**
+
+**Opção B — Ativar atualização automática:**
+1. Vá em **Configurações → Plugins da comunidade**
+2. Ative **Verificar automaticamente atualizações de plugins**
+
+> 💡 **Por que manter-se atualizado?** Cada versão pode incluir novos recursos, melhorias de desempenho e correções de bugs importantes.
+
+### 🔑 Configurar um provedor LLM
+
+1. Abra Configurações → Karpathy LLM Wiki
+2. Escolha um provedor no menu suspenso
+3. Insira sua chave API (não necessária para Ollama)
+4. Clique em **Fetch Models**, ou digite o nome de um modelo manualmente
+5. Clique em **Test Connection**, depois **Salvar configurações**
+
+**🦙 Ollama (local):** Instale o [Ollama](https://ollama.com), baixe um modelo, selecione "Ollama (Local)".
+
+**🎛️ LM Studio (local):** Instale o [LM Studio](https://lmstudio.ai), inicie o servidor local, selecione "LM Studio (Local)".
+
+### 🎮 Uso
+
+| Método | Como |
+|--------|------|
+| **📥 Ingerir fonte individual** | `Cmd+P` → "Ingerir fonte individual" |
+| **📂 Ingerir de pasta** | `Cmd+P` → "Ingerir de pasta" |
+| **🔍 Consultar Wiki** | `Cmd+P` → "Consultar Wiki" |
+| **🛠️ Verificar Wiki** | `Cmd+P` → "Verificar Wiki" |
+| **📋 Regenerar índice** | `Cmd+P` → "Regenerar índice" |
+| **💡 Sugerir atualizações de Schema** | `Cmd+P` → "Sugerir atualizações de Schema" |
+| **🎯 Ingestão com um clique** | Ícone da barra lateral ou `Cmd+P` → "Ingerir arquivo atual" |
+
+### ⚠️ Atualizando de uma versão anterior?
+
+**Esta versão é totalmente retrocompatível.** Sem mudanças incompatíveis desde v1.0.0.
+
+**Para wikis construídos com múltiplas versões:**
+1️⃣ Reconstrua seu índice — "Regenerar índice"
+2️⃣ Execute Verificar Wiki — escaneia problemas
+3️⃣ Use Smart Fix All — reparação com um clique
+4️⃣ Ative geração paralela de páginas — Concorrência: 3, Atraso: 300ms
+5️⃣ Revise as configurações — Idioma, Granularidade, Auto-Manutenção
 
 ---
 


### PR DESCRIPTION
## Summary
Add Quick Start section to 6 non-English READMEs, add Why section to all, sync CLAUDE.md/CONTRIBUTING.md architecture.

## Test plan
- [x] Gate 1: lint 0/0, tsc 0, test 771/771, build clean
- [x] All 8 READMEs have Quick Start, Why, What's New sections
- [x] CLAUDE.md project structure reflects current src/

Co-Authored-By: Claude Code <noreply@anthropic.com>