### PR TITLE
fix(llm-client): build Anthropic fallback messages without a system role (#141)

### DIFF
--- a/src/__tests__/root/llm-client-anthropic-prefill.test.ts
+++ b/src/__tests__/root/llm-client-anthropic-prefill.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { requestUrl } from 'obsidian';
-import { AnthropicClient } from '../../llm-client';
+import { AnthropicClient, AnthropicCompatibleClient } from '../../llm-client';
 
 // v1.20.1 hotfix: AnthropicClient prefill-not-supported fallback.
 //
@@ -50,6 +50,28 @@ function makeSuccessResponse(text: string): Awaited<ReturnType<typeof requestUrl
 function getBodyFromCall(callIndex: number): { messages: Array<{ role: string }> } {
   const callArgs = mockRequestUrl.mock.calls[callIndex][0] as unknown as { body: string };
   return JSON.parse(callArgs.body) as { messages: Array<{ role: string }> };
+}
+
+// Like getBodyFromCall but also exposes top-level `system` / `thinking` — needed
+// to assert the Anthropic contract (system is a top-level param, never a role).
+function getFullBody(callIndex: number): {
+  messages: Array<{ role: string }>;
+  system?: string;
+  thinking?: unknown;
+} {
+  const callArgs = mockRequestUrl.mock.calls[callIndex][0] as unknown as { body: string };
+  return JSON.parse(callArgs.body) as { messages: Array<{ role: string }>; system?: string; thinking?: unknown };
+}
+
+function makeErrorResponse(status: number, message: string): Awaited<ReturnType<typeof requestUrl>> {
+  // throw:false → requestUrl resolves a response object even on 4xx.
+  return {
+    status,
+    text: JSON.stringify({ type: 'error', error: { type: 'invalid_request_error', message } }),
+    json: { type: 'error', error: { type: 'invalid_request_error', message } },
+    headers: {},
+    arrayBuffer: async () => new ArrayBuffer(0),
+  } as unknown as Awaited<ReturnType<typeof requestUrl>>;
 }
 
 describe('AnthropicClient prefill-not-supported fallback (#141, #147)', () => {
@@ -140,5 +162,136 @@ describe('AnthropicClient prefill-not-supported fallback (#141, #147)', () => {
 
     const body = getBodyFromCall(0);
     expect(body.messages.every(m => m.role === 'user')).toBe(true);
+  });
+});
+
+// Issue #141 regression: even though v1.20.2 detects the prefill rejection
+// correctly (throw:false + "Prefilling..." match), the no-prefill RETRY body
+// injected `{ role: 'system' }` into messages while ALSO setting top-level
+// system. The Anthropic Messages API only accepts user/assistant roles in
+// messages (system must be top-level), so the retry produced a SECOND 400 and
+// ingestion failed. Production ingestion ALWAYS sends a system prompt — the
+// tests above never did, so they missed this branch entirely.
+
+// Simulates the real Anthropic Messages API under throw:false:
+//   - assistant prefill (last message role 'assistant') → 400 "Prefilling..."
+//   - any 'system' role inside messages[] → 400 (system must be top-level)
+//   - otherwise → 200
+function anthropicPrefillSim(text: string): typeof requestUrl {
+  const impl = (opts: unknown): Promise<unknown> => {
+    const body = JSON.parse((opts as { body: string }).body) as { messages: Array<{ role: string }> };
+    const last = body.messages[body.messages.length - 1];
+    if (last?.role === 'assistant') {
+      return Promise.resolve(makeErrorResponse(400, 'Prefilling assistant messages is not supported for this model.'));
+    }
+    if (body.messages.some(m => m.role === 'system')) {
+      return Promise.resolve(makeErrorResponse(400, "messages.0.role: Input should be 'user' or 'assistant'"));
+    }
+    return Promise.resolve(makeSuccessResponse(text));
+  };
+  return impl as unknown as typeof requestUrl;
+}
+
+// Simulates an endpoint that rejects thinking.type='disabled':
+//   - any body carrying a `thinking` field → thinking-control 400
+//   - any 'system' role inside messages[] → 400
+function anthropicThinkingSim(text: string): typeof requestUrl {
+  const impl = (opts: unknown): Promise<unknown> => {
+    const body = JSON.parse((opts as { body: string }).body) as { messages: Array<{ role: string }>; thinking?: unknown };
+    if (body.thinking !== undefined) {
+      return Promise.resolve(makeErrorResponse(400, 'unknown field: thinking'));
+    }
+    if (body.messages.some(m => m.role === 'system')) {
+      return Promise.resolve(makeErrorResponse(400, "messages.0.role: Input should be 'user' or 'assistant'"));
+    }
+    return Promise.resolve(makeSuccessResponse(text));
+  };
+  return impl as unknown as typeof requestUrl;
+}
+
+const SYSTEM_PROMPT = 'You are a wiki extraction engine.';
+
+describe('Anthropic prefill fallback with a system prompt (#141 regression)', () => {
+  beforeEach(() => {
+    mockRequestUrl.mockReset();
+  });
+
+  it('AnthropicClient: ingestion (system + json_object) succeeds after prefill fallback', async () => {
+    mockRequestUrl.mockImplementation(anthropicPrefillSim('{"result":"ok"}'));
+
+    const client = new AnthropicClient('test-key', 'https://api.anthropic.com');
+    const result = await client.createMessage({
+      model: 'claude-opus-4-8',
+      max_tokens: 100,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: 'Analyze this source' }],
+      response_format: { type: 'json_object' },
+    });
+
+    expect(result).toContain('ok');
+    const retry = getFullBody(mockRequestUrl.mock.calls.length - 1);
+    expect(retry.messages.some(m => m.role === 'system')).toBe(false);
+    expect(retry.messages.some(m => m.role === 'assistant')).toBe(false);
+    expect(retry.system).toBe(SYSTEM_PROMPT);
+  });
+
+  it('AnthropicCompatibleClient: ingestion (system + json_object) succeeds after prefill fallback', async () => {
+    mockRequestUrl.mockImplementation(anthropicPrefillSim('{"result":"ok"}'));
+
+    const client = new AnthropicCompatibleClient('test-key', 'https://example.com/v1');
+    const result = await client.createMessage({
+      model: 'claude-opus-4-8',
+      max_tokens: 100,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: 'Analyze this source' }],
+      response_format: { type: 'json_object' },
+    });
+
+    expect(result).toContain('ok');
+    const retry = getFullBody(mockRequestUrl.mock.calls.length - 1);
+    expect(retry.messages.some(m => m.role === 'system')).toBe(false);
+    expect(retry.system).toBe(SYSTEM_PROMPT);
+  });
+});
+
+describe('Anthropic thinking-disabled fallback with a system prompt (#141 regression)', () => {
+  beforeEach(() => {
+    mockRequestUrl.mockReset();
+  });
+
+  it('AnthropicClient: thinking fallback keeps system top-level, no system role in messages', async () => {
+    mockRequestUrl.mockImplementation(anthropicThinkingSim('hello'));
+
+    const client = new AnthropicClient('test-key', 'https://api.anthropic.com');
+    const result = await client.createMessage({
+      model: 'claude-opus-4-8',
+      max_tokens: 100,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: 'Hi' }],
+      enableThinking: false,
+    });
+
+    expect(result).toBe('hello');
+    const fb = getFullBody(mockRequestUrl.mock.calls.length - 1);
+    expect(fb.messages.some(m => m.role === 'system')).toBe(false);
+    expect(fb.system).toBe(SYSTEM_PROMPT);
+  });
+
+  it('AnthropicCompatibleClient: thinking fallback keeps system top-level, no system role in messages', async () => {
+    mockRequestUrl.mockImplementation(anthropicThinkingSim('hello'));
+
+    const client = new AnthropicCompatibleClient('test-key', 'https://example.com/v1');
+    const result = await client.createMessage({
+      model: 'claude-opus-4-8',
+      max_tokens: 100,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: 'Hi' }],
+      enableThinking: false,
+    });
+
+    expect(result).toBe('hello');
+    const fb = getFullBody(mockRequestUrl.mock.calls.length - 1);
+    expect(fb.messages.some(m => m.role === 'system')).toBe(false);
+    expect(fb.system).toBe(SYSTEM_PROMPT);
   });
 });

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -272,9 +272,7 @@ export class AnthropicCompatibleClient implements LLMClient {
         const noPrefillBody: Record<string, unknown> = {
           model: params.model,
           max_tokens: params.max_tokens,
-          messages: params.system
-            ? [{ role: 'system' as const, content: params.system }, ...params.messages]
-            : [...params.messages],
+          messages: [...params.messages],
         };
         if (params.system) noPrefillBody.system = params.system;
         if (params.temperature !== undefined) noPrefillBody.temperature = params.temperature;
@@ -290,10 +288,9 @@ export class AnthropicCompatibleClient implements LLMClient {
         const fallbackBody: Record<string, unknown> = {
           model: params.model,
           max_tokens: params.max_tokens,
-          messages: params.system
-            ? [{ role: 'system' as const, content: params.system }, ...params.messages]
-            : params.messages,
+          messages: [...params.messages],
         };
+        if (params.system) fallbackBody.system = params.system;
         if (params.response_format?.type === 'json_object') {
           fallbackBody.messages = [...(fallbackBody.messages as Array<Record<string, unknown>>), { role: 'assistant', content: '{' }];
         }
@@ -562,9 +559,7 @@ export class AnthropicClient implements LLMClient {
         const noPrefillBody: Record<string, unknown> = {
           model: params.model,
           max_tokens: params.max_tokens,
-          messages: params.system
-            ? [{ role: 'system' as const, content: params.system }, ...params.messages]
-            : [...params.messages],
+          messages: [...params.messages],
         };
         if (params.system) noPrefillBody.system = params.system;
         if (params.temperature !== undefined) noPrefillBody.temperature = params.temperature;
@@ -580,9 +575,7 @@ export class AnthropicClient implements LLMClient {
         const fallbackBody: Record<string, unknown> = {
           model: params.model,
           max_tokens: params.max_tokens,
-          messages: params.system
-            ? [{ role: 'system' as const, content: params.system }, ...params.messages]
-            : [...params.messages],
+          messages: [...params.messages],
         };
         if (params.system) fallbackBody.system = params.system;
         if (params.temperature !== undefined) fallbackBody.temperature = params.temperature;


### PR DESCRIPTION
## Summary

Fixes #141. On newer Claude models (Opus 4.8, Sonnet 4.6, Fable 5, Mythos 5) the Anthropic provider passes **Test Connection** but **Ingestion fails with HTTP 400**.

`main` (v1.20.2-v2, #150) already does the hard part right: with `throw: false` it reads the Anthropic error body and correctly **detects** the prefill rejection (`"Prefilling assistant messages is not supported"`), then retries without prefill. **But the retry itself 400s**, so ingestion never lands.

## Root cause

The no-prefill retry body — and the thinking-disabled fallback body — build `messages` like this:

```ts
messages: params.system
  ? [{ role: 'system', content: params.system }, ...params.messages]  // ← bug
  : [...params.messages],
// ...
if (params.system) noPrefillBody.system = params.system;              // also top-level
```

It injects a `role: 'system'` **message** into the `messages` array (OpenAI style) while *also* setting the top-level `system`. The Anthropic Messages API only accepts `user`/`assistant` roles in `messages` — `system` must be a top-level parameter — so the retry returns:

```
400 messages.0.role: Input should be 'user' or 'assistant'
```

Ingestion always sends a system prompt, so this branch is **always** taken and the prefill fallback never succeeds.

Affected: all four Anthropic fallback bodies (`AnthropicClient` + `AnthropicCompatibleClient`, both the no-prefill and thinking-disabled paths). The `AnthropicCompatibleClient` thinking-disabled fallback additionally dropped the top-level `system` entirely. The original (prefill) request body was always correct, and the `{ role: 'system' }` idiom remains correct for the OpenAI-compatible client (left unchanged).

## Fix

Build the fallback `messages` as user/assistant only (`[...params.messages]`) and keep `system` top-level; add the missing top-level `system` to the compat thinking fallback.

## Why the existing tests missed it

`llm-client-anthropic-prefill.test.ts`'s four tests never pass a `system` prompt, so the `params.system ? …` branch — the one production always hits — was never exercised, and the success mock returns 200 regardless of body validity. This PR adds 4 regression tests that pass a `system` prompt and simulate the real API rejecting a `system` role in `messages` under `throw: false`. They fail on current `main`, pass with the fix.

## Test plan

- [x] `pnpm test` — **779 passing** (4 new), 0 regressions
- [x] `pnpm lint` — 0 errors / 0 warnings
- [x] `npx tsc --noEmit` — 0 errors
- [x] `pnpm build` — clean
- [x] **Live against the real `claude-opus-4-8` endpoint** — an ingestion that previously failed with 400 now completes cleanly (11 pages created, 1 updated)

## Gate 4: Performance

| Dim | Status | Notes |
|-----|--------|-------|
| CPU | ✅ | Removes one element from a cold fallback array build; no new loops. |
| Memory | ✅ | One fewer transient message object; no new caches. |
| IO | N/A | No vault IO in change scope. |
| Network | ✅ | Net **fewer** LLM round-trips — the prefill fallback now succeeds on the first retry instead of throwing a second 400. |
| Token | ✅ | Identical prompt content; no change to tokens sent. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
