### PR TITLE
docs(roadmap+claude): track #164 empty-content bug in v1.21.0 plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,15 @@
 # LLM Wiki Plugin Project Development Standards
 
-**Last Updated:** 2026-06-20
+**Last Updated:** 2026-06-21
 
 ---
 
-## Current Phase: v1.20.3 Released — v1.21.0 Schema Coherence Phase 1 (Planned)
+## Current Phase: v1.20.3 Released — v1.21.0 Schema Coherence Phase 1 (in development)
+
+### In Progress — v1.21.0
+- 🔴 **#164 — Empty-content hallucinated entity bug.** Reported by @Indexed-Apogrypha 2026-06-21; root cause confirmed (missing empty-content guard in `WikiEngine.ingestSource` and `SourceAnalyzer.analyzeSource`). PR incoming; fold into v1.21.0 (not v1.20.4 hotfix) per user decision.
+- 🟢 **#124 — Schema Coherence Phase 1.** Local branch `feat/v1.21.0-schema-coherence-phase1` (commit `4251aa9`).
+- 🟢 **Italian locale + i18n-parity test (PR #159).** 9th locale shipped.
 
 ### Completed (v1.20.3) — Hotfix 2026-06-20
 - ✅ **Source-slug fingerprint (PR #156, Closes #155).** Every source slug now `<basename>_<6hex FNV-1a of full path>` — fixes silent overwrite when two source files share a basename across folders. Contributed by @Indexed-Apogrypha.
@@ -47,8 +52,8 @@
 - ✅ **Tests: 744 passing (was 728).** 36 test files, 0 regressions. +16 tests since v1.19.0 (new `llm-client-gemini-fallback` + `settings-thinkcache` suites).
 
 ### P0 — Bug fixes / quality regressions
-All v1.18.x P0 items closed. Next window opens with post-v1.19.0 feedback.
-All v1.18.x P0 items closed. Next window opens with post-v1.19.0 feedback.
+- 🔴 **#164 — Empty-content hallucinated entity (v1.21.0, in PR).** Critical bug. Reported by @Indexed-Apogrypha 2026-06-21. Fix path: guard at `WikiEngine.ingestSource` entry + unit + integration tests + 9-locale i18n.
+- All v1.20.x P0 items closed (Anthropic prefill v1.20.1, system-role v1.20.2, source-slug/alias-dedup/reviewed-guard v1.20.3).
 
 ### P1 — Cleanup (v1.19.0 target, deferred items from v1.18.x)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Feature planning and improvement proposals
 
-**Version:** 1.20.3 | **Updated:** 2026-06-20
+**Version:** 1.20.3 | **Updated:** 2026-06-21
 
 ---
 
@@ -107,6 +107,7 @@ Release focus: ship Schema Coherence Phase 1 (`SchemaContext` + `buildSchemaSect
 - **`buildActiveTagVocabularySection` injection into system prompt** with dedup guard. Custom tags now active in every LLM call that needs them.
 - **Settings UI default mode** previews user-defined custom tags with activation hint.
 - **v1.20.0 migration** resets `disableThinking` to `false` and `advancedSettingsMode` to `'default'` (already shipped).
+- 🔴 **#164 — Empty-content hallucinated entity guard** (in PR by @Indexed-Apogrypha). Add early-return in `WikiEngine.ingestSource` (line ~248, right after `vault.read`): if `fileContent.trim().length === 0` → emit `emptySourceNotice` + return. Plus 9-locale i18n + unit + integration tests. Closes a critical bug where local models (Ollama gemma4, qwen-coder) hallucinate entity names from empty input prompts.
 
 ### Phase 2 (next, after Phase 1 lands)
 - Wire `generation.ts` to consume `buildSchemaSectionTemplate` (replace hardcoded `## {{section_xxx}}`).


### PR DESCRIPTION
## Summary

Documentation-only update reflecting two decisions from 2026-06-21:

1. **#164 folds into v1.21.0** (not a standalone v1.20.4 hotfix). @Indexed-Apogrypha confirmed they will PR the fix. The fix is small and orthogonal; bundling with Schema Coherence Phase 1 keeps the release cadence clean.
2. **Hybrid fingerprint** (FM-default + filename-on-collision) is recorded as an optional future path only — deferred to v1.22.0+ for low ROI. Triggers documented for future reconsideration.

## What changed (2 files, +11/-5)

- **CLAUDE.md**: `Last Updated` → 2026-06-21; `Current Phase` → "in development"; new `In Progress — v1.21.0` section (lists #164 in PR, Schema Phase 1, Italian locale); `P0` table now has a live #164 entry (was a historical placeholder).
- **ROADMAP.md**: `Version/Updated` → 2026-06-21; `Phase 1: Schema Coherence` adds #164 empty-content guard as a Phase 1 work item.

## Why docs-only

Per the standing directive after PR #161: docs-only, no version bump, no tag, no release. v1.21.0 ships after Schema Phase 1 PR + #164 PR both land.

## Test plan

- [x] `pnpm lint` — 0/0
- [x] `npx tsc --noEmit` — 0
- [x] `pnpm test` — 813 pass
- [x] `pnpm build` — clean
- [x] Manual diff-read: no breaking changes