### PR TITLE
test(i18n): extend bidirectional parity to all 9 locales + drop ZH orphan

### DIFF
--- a/src/__tests__/root/i18n-parity.test.ts
+++ b/src/__tests__/root/i18n-parity.test.ts
@@ -35,11 +35,16 @@ describe('UI text parity across all locales', () => {
     expect(empties, `empty values in ${locale}`).toEqual([]);
   });
 
-  // The newly added Italian locale is held to strict bidirectional parity:
-  // no missing keys and no extra keys versus en.
-  it('it locale is at exact bidirectional parity with en', () => {
-    const itKeys = Object.keys(TEXTS.it).sort();
-    expect(itKeys).toEqual(EN_KEYS);
+  // Every locale (including the legacy ones) is held to strict bidirectional
+  // parity: no missing keys and no extra keys versus en. Real-world hit:
+  // ZH had `lintReportPageCount` as an orphan from PR #110 (status-bar
+  // mirror) without an EN counterpart — exactly the bug this guard exists
+  // to prevent. Italian's check is now part of this parameterization
+  // (instead of a one-off) so any new locale automatically gets the same
+  // strict coverage.
+  it.each(LOCALES)('locale "%s" is at exact bidirectional parity with en', (locale) => {
+    const keys = Object.keys(TEXTS[locale]).sort();
+    expect(keys).toEqual(EN_KEYS);
   });
 });
 

--- a/src/texts/zh.ts
+++ b/src/texts/zh.ts
@@ -408,7 +408,6 @@ export const ZH_TEXTS = {
 
     // 维护报告
     lintReportTitle: 'Wiki 维护报告',
-    lintReportPageCount: '共 {count} 个 Wiki 页面',
     lintReportSummary: 'Wiki 状态概览：共 {total} 个页面，{aliasesMissing} 个缺失别名，重复 {duplicates} 个，断链 {deadLinks} 个（其中 {deadLinkFromDup} 个涉及重复页面），孤立 {orphans} 个（其中 {orphanFromDup} 个是重复页面），空洞 {emptyPages} 个，无来源引证 {ungroundedQuotes} 个，标签越界 {tagViolations} 个。本次 Lint 耗时 {elapsedSeconds} 秒',
 
     // Advanced LLM Settings (Issues #99 / #128)


### PR DESCRIPTION
## Summary

Two related changes that close a latent bilingual bug:

1. **Extend bidirectional parity test to all 9 locales** —  instead of one-shot IT-only check.
2. **Drop orphan ZH key** exposed by the expanded test.

## Why this matters

The previous parity test had forward parity (every locale covers every EN key) for all 9 locales via `it.each(LOCALES)`, but **reverse parity (no orphan keys)** was a one-shot test only for Italian. Any orphan key added to a legacy locale (zh, ja, ko, de, fr, es, pt) by a partial-translation commit would accumulate silently.

The expanded test immediately caught a real-world case: `lintReportPageCount` in ZH — added by PR #110 (@dmarchevsky, 2026-06-16) as a Chinese-only translation with no EN counterpart, and never referenced from any `src/` code path. Pure dead code from an incomplete translation.

## What changed (2 files, +10/-6)

- **`src/__tests__/root/i18n-parity.test.ts`**: generalize the bidirectional check from `it('it locale ...')` to `it.each(LOCALES)('locale "%s" is at exact bidirectional parity with en', ...)`. One-shot IT test removed (Italian is now covered by the parameterized loop).
- **`src/texts/zh.ts`**: delete the orphan `lintReportPageCount: '共 {count} 个 Wiki 页面'` entry.

## Test plan

- [x] `pnpm lint` — 0 errors / 0 warnings
- [x] `npx tsc --noEmit` — 0 errors
- [x] `pnpm test` — **821 passing** (was 813; +8 from `it.each` parameterization: 9 locales × 1 bidirectional check, minus 1 old one-shot = +8 effective test cases)
- [x] `pnpm build` — clean exit
- [x] Manual verification: `Object.keys(TEXTS.en).sort()` === `Object.keys(TEXTS[locale]).sort()` for all 9 locales (396 keys each)

## Scope

This is a **test + dead-code-cleanup** PR:
- No shipped behavior change (orphan key was never used)
- No version bump needed (pure test + dead code cleanup)
- All 9 locales verified at exact key-for-key parity with EN

## Future-proofing

A feedback memory `feedback_i18n_parity_bidirectional_coverage.md` captures the rule: **adding a new locale requires the i18n-parity test to already be `it.each`-based**. A new locale with a one-shot per-locale parity test is incomplete — it gets stricter coverage than legacy locales, defeating parity.