### PR TITLE
feat(schema): v1.21.0 Phase 1 — SchemaContext + buildSchemaSectionTemplate + tag vocab injection (Closes #124)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,6 +309,41 @@ Every code change via `Read` + `Edit`. No sed/awk/python AST for code. (2026-06-
 
 - **NEVER commit or push without explicit user permission.** Non-negotiable.
 
+## 🔀 Git Branch Workflow (enforced since v1.20.2)
+
+**Core principle: Never develop directly on main. Main only accepts PR merges.**
+
+```
+main (protected) ───────────────────────→ tag → release
+  │
+  ├── feat/xxx ── PR → review → merge
+  │     ├── commit 1
+  │     ├── commit 2
+  │     └── commit 3
+  │
+  └── fix/xxx ── PR → review → merge
+        └── commit 1
+```
+
+**Development flow (mandatory for every feature/fix):**
+
+1. **Branch from main:** `git checkout -b feat/xxx` or `git checkout -b fix/xxx`
+2. **Develop on the branch** — multiple commits OK, each with meaningful content
+3. **Gate 1 verification:** `pnpm lint && npx tsc --noEmit && pnpm test && pnpm build`
+4. **Only after user confirmation** — push branch, create PR
+5. **After PR merge** — switch back to main, pull, tag (if needed)
+
+**Prohibited:**
+- ❌ Committing directly on main (except lockfile-only changes)
+- ❌ Pushing PR without user confirmation
+- ❌ Mixing unrelated changes in one PR
+- ❌ Fragmented commits (amend the previous commit or squash)
+
+**When to amend vs new commit:**
+- Fixing a problem in the previous commit → `git commit --amend`
+- New feature / new fix → new commit
+- Pre-release doc updates → can amend into the version bump commit
+
 ## 📦 Development Workflow
 
 1. `pnpm lint && pnpm test && npx tsc --noEmit && pnpm build` — all four must pass (Six-Gate Gate 1)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,24 +95,47 @@ Major quality release addressing previously-unprocessable large sources and a cl
 
 ---
 
-## Next Milestone: v1.21.0 — Schema Coherence Phase 1 (in progress)
+## Next Milestone: v1.21.0 — Schema Coherence Phase 1
 
-v1.20.0 (2026-06-18) shipped provider-first thinking control + reasoning UI; v1.20.1–v1.20.3 (2026-06-18 to 2026-06-20) shipped four parity/latent-bug hotfixes (Anthropic prefill, Anthropic system-role, source-slug fingerprint, Stage-4 reviewed guard) and added Italian locale (9 languages total).
+Release focus: unify schema as the single source of truth for both system prompts and generation prompts, fixing three concrete inconsistencies confirmed via code review (see [Issue #124](https://github.com/green-dalii/obsidian-llm-wiki/issues/124), [Issue #97](https://github.com/green-dalii/obsidian-llm-wiki/issues/97)).
 
-Release focus: ship Schema Coherence Phase 1 (`SchemaContext` + `buildSchemaSectionTemplate` + tag vocabulary injection), then continue to Phase 2/3. Italian locale + i18n-parity test already in main from v1.20.3 hotfix cycle.
+### Phase 1: Schema → Prompt Unification (v1.21.0)
 
-### Phase 1: Schema Coherence (in progress)
-- **`SchemaContext`** shared parsed representation of `schema/config.md`, used by both system prompts and generation prompts (eliminates the "schema template overridden by hardcoded sections" bug from #124).
-- **`buildSchemaSectionTemplate(ctx, pageType)`** extracts user-defined sections from `**Sections:**` lists; `hasUserSections` flag for backward compat.
-- **`buildActiveTagVocabularySection` injection into system prompt** with dedup guard. Custom tags now active in every LLM call that needs them.
-- **Settings UI default mode** previews user-defined custom tags with activation hint.
-- **v1.20.0 migration** resets `disableThinking` to `false` and `advancedSettingsMode` to `'default'` (already shipped).
-- 🔴 **#164 — Empty-content hallucinated entity guard** (in PR by @Indexed-Apogrypha). Add early-return in `WikiEngine.ingestSource` (line ~248, right after `vault.read`): if `fileContent.trim().length === 0` → emit `emptySourceNotice` + return. Plus 9-locale i18n + unit + integration tests. Closes a critical bug where local models (Ollama gemma4, qwen-coder) hallucinate entity names from empty input prompts.
+**Problem:** Three concrete inconsistencies between user-configured schema (`schema/config.md`) and runtime prompt construction:
 
-### Phase 2 (next, after Phase 1 lands)
-- Wire `generation.ts` to consume `buildSchemaSectionTemplate` (replace hardcoded `## {{section_xxx}}`).
-- Custom section name syntax extensions.
-- #97 one-click apply with auto-backup + diff preview (depends on Phase 1 single-source-of-truth).
+1. **Section structure hardcoded in user prompts.** `src/wiki/prompts/generation.ts` lines 57-70 hardcode `## {{section_basic_information}}`, `## {{section_description}}`, etc. in the user prompt, while `schema/config.md` templates go into the system prompt. Two conflicting definitions in one LLM call.
+2. **Tag vocabulary only injected into lint paths.** `buildActiveTagVocabularySection` in `system-prompts.ts:213` is called by lint-analyze and fix-runners, but NOT by `buildSystemPrompt` or `generation.ts`. Users on Custom tag vocabulary see their settings silently ignored for page generation.
+3. **Settings UI description drift.** `settings.ts:720` shows hardcoded `VALID_ENTITY_TAGS` in the default-mode description, but the actual runtime uses `getActiveEntityTags(settings)` which switches to user-defined CSV in Custom mode.
+
+**Plan (minimum-invasive, backward compatible):**
+
+- Extract `SchemaContext` type as shared input for `buildSystemPrompt` + `generation.ts`
+- `generation.ts` reads section structure from schema, not from `## {{section_xxx}}` placeholders
+- `buildSystemPrompt` injects the tag vocabulary section
+- Settings description uses `getActiveEntityTags/Concepts` for live alignment
+- Default fallback: when schema doesn't define custom sections, use the current hardcoded templates (no behavior change for users who haven't customized schema)
+
+**Acceptance criteria:**
+
+- Schema customization in `config.md` propagates to actual generated pages (not silently overridden)
+- Custom tag vocabulary in settings is respected by all ingestion paths
+- Existing wikis (with default schema) produce identical output before and after
+- Tests pass for both default-schema and custom-schema paths
+
+**🔴 #164 — Empty-content hallucinated entity guard** (in PR by @Indexed-Apogrypha). Add early-return in `WikiEngine.ingestSource` (line ~248, right after `vault.read`): if `fileContent.trim().length === 0` → emit `emptySourceNotice` + return. Plus 9-locale i18n + unit + integration tests. Closes a critical bug where local models (Ollama gemma4, qwen-coder) hallucinate entity names from empty input prompts. Folded into v1.21.0 with Schema Phase 1 to avoid two consecutive hotfixes within a week.
+
+### Phase 2: Custom section names + #97 one-click apply (v1.21.0 or v1.22.0)
+
+- Schema supports custom section names (not just multi-language translation)
+- One-click apply schema suggestions with auto-backup
+- Schema diff preview before apply
+- Rollback mechanism
+
+### Phase 3: Graph-based features & Workflow scale-up (v1.22.0+)
+
+- **#117 — Graph-based domain tag inference.** Hub detection + cheap LLM labeling + tag propagation with explainability.
+- **#122 — Ingestion history panel.** Start with log.md UI layer.
+- **#130 — In-place batch ingest queue.** Composes with #122 and `pageGenerationConcurrency`.
 
 ### Out of scope (v1.21.0+)
 

--- a/src/__tests__/schema/schema-context.test.ts
+++ b/src/__tests__/schema/schema-context.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { parseSchemaContext } from '../../schema/schema-context';
+import { buildDefaultSchemaBody } from '../../schema/schema-manager';
+
+describe('parseSchemaContext', () => {
+  describe('default schema body (backward compatibility)', () => {
+    const body = buildDefaultSchemaBody();
+
+    it('extracts entity sections from default schema', () => {
+      const ctx = parseSchemaContext(body, 'entity');
+      expect(ctx.sections.length).toBeGreaterThan(0);
+      // Default entity template has these sections (Issue #85 / default schema)
+      const headings = ctx.sections.map(s => s.heading);
+      expect(headings).toContain('Entity Page Template');
+    });
+
+    it('returns empty sections array for unknown page type but still parses body', () => {
+      const ctx = parseSchemaContext(body, 'unknown-type');
+      // Unknown types still parse sections (we don't filter by type here)
+      expect(ctx.sections.length).toBeGreaterThan(0);
+      expect(ctx.body).toBe(body);
+    });
+
+    it('preserves raw body for fallback', () => {
+      const ctx = parseSchemaContext(body, 'entity');
+      expect(ctx.body).toBe(body);
+    });
+  });
+
+  describe('custom schema body (user-edited config.md)', () => {
+    const customBody = `# Wiki Schema
+
+## Entity Page Template
+
+**Sections:**
+1. **Overview**: Single paragraph summary
+2. **Timeline**: Chronological events
+3. **Connections**: Related entities
+
+## Concept Page Template
+
+**Sections:**
+1. **Definition**: Brief definition
+2. **Examples**: Real-world examples
+
+## Custom Section Title
+
+This is a custom user-defined section.
+`;
+
+    it('parses user-defined sections', () => {
+      const ctx = parseSchemaContext(customBody, 'entity');
+      const headings = ctx.sections.map(s => s.heading);
+      expect(headings).toContain('Entity Page Template');
+      expect(headings).toContain('Concept Page Template');
+      expect(headings).toContain('Custom Section Title');
+    });
+
+    it('extracts section content including body lines', () => {
+      const ctx = parseSchemaContext(customBody, 'entity');
+      const customSection = ctx.sections.find(s => s.heading === 'Custom Section Title');
+      expect(customSection).toBeDefined();
+      expect(customSection?.content).toContain('custom user-defined section');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty body', () => {
+      const ctx = parseSchemaContext('', 'entity');
+      expect(ctx.sections).toEqual([]);
+      expect(ctx.body).toBe('');
+    });
+
+    it('handles body without any sections', () => {
+      const ctx = parseSchemaContext('Just plain text without headings.', 'entity');
+      expect(ctx.sections).toEqual([]);
+      expect(ctx.body).toBe('Just plain text without headings.');
+    });
+
+    it('treats top-level title (single #) separately from sections', () => {
+      const body = '# Wiki Schema\n\n## Section A\nContent A';
+      const ctx = parseSchemaContext(body, 'entity');
+      expect(ctx.sections.map(s => s.heading)).toEqual(['Section A']);
+    });
+  });
+
+  describe('hasUserSections flag (for prompt-unification logic)', () => {
+    it('returns hasUserSections=false when sections match default schema', () => {
+      const ctx = parseSchemaContext(buildDefaultSchemaBody(), 'entity');
+      // The default schema includes all built-in templates — flag should be false
+      // because there's nothing "custom" the user added
+      expect(ctx.hasUserSections).toBe(false);
+    });
+
+    it('returns hasUserSections=true when body contains sections not in default', () => {
+      const customBody = buildDefaultSchemaBody() + '\n\n## My Custom Section\nUser added this.';
+      const ctx = parseSchemaContext(customBody, 'entity');
+      expect(ctx.hasUserSections).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/schema/schema-section-template.test.ts
+++ b/src/__tests__/schema/schema-section-template.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { buildSchemaSectionTemplate } from '../../schema/schema-context';
+import { buildDefaultSchemaBody } from '../../schema/schema-manager';
+import { parseSchemaContext } from '../../schema/schema-context';
+
+describe('buildSchemaSectionTemplate', () => {
+  describe('default schema (backward compat — no behavior change)', () => {
+    it('returns canonical entity sections when schema is default', () => {
+      const ctx = parseSchemaContext(buildDefaultSchemaBody(), 'entity');
+      const tpl = buildSchemaSectionTemplate(ctx, 'entity');
+      // Default behavior: canonical entity sections (no change from v1.20.0)
+      expect(tpl).toContain('## Basic Information');
+      expect(tpl).toContain('## Description');
+      expect(tpl).toContain('## Related Entities');
+      expect(tpl).toContain('## Related Concepts');
+      expect(tpl).toContain('## Mentions in Source');
+    });
+
+    it('returns canonical concept sections for concept page type', () => {
+      const ctx = parseSchemaContext(buildDefaultSchemaBody(), 'concept');
+      const tpl = buildSchemaSectionTemplate(ctx, 'concept');
+      expect(tpl).toContain('## Definition');
+      expect(tpl).toContain('## Key Characteristics');
+      expect(tpl).toContain('## Applications');
+    });
+
+    it('returns canonical source sections for source page type', () => {
+      const ctx = parseSchemaContext(buildDefaultSchemaBody(), 'source');
+      const tpl = buildSchemaSectionTemplate(ctx, 'source');
+      expect(tpl).toContain('## Summary');
+      expect(tpl).toContain('## Key Points');
+      expect(tpl).toContain('## Mentioned Pages');
+    });
+  });
+
+  describe('custom schema (user customization propagates)', () => {
+    it('extracts section names from user-defined `**Sections:**` list', () => {
+      const customBody = `# Wiki Schema
+
+## Entity Page Template
+
+**Sections:**
+1. **Overview**: Single paragraph summary
+2. **Timeline**: Chronological events
+3. **Connections**: Related entities
+
+## Concept Page Template
+
+**Sections:**
+1. **Definition**: Brief definition
+2. **Examples**: Real-world examples
+
+## My Custom Section
+
+User added a new top-level section.
+`;
+      const ctx = parseSchemaContext(customBody, 'entity');
+      // Sanity: hasUserSections should be true (My Custom Section not in defaults)
+      expect(ctx.hasUserSections).toBe(true);
+      const tpl = buildSchemaSectionTemplate(ctx, 'entity');
+      // User's section names flow through
+      expect(tpl).toContain('## Overview');
+      expect(tpl).toContain('## Timeline');
+      expect(tpl).toContain('## Connections');
+      // Default sections should NOT appear when user customized
+      expect(tpl).not.toContain('## Basic Information');
+      expect(tpl).not.toContain('## Description');
+    });
+
+    it('returns empty template when schema has no Entity Page Template section', () => {
+      const body = '## Concept Page Template\n**Sections:**\n1. **Definition**: x';
+      const ctx = parseSchemaContext(body, 'entity');
+      const tpl = buildSchemaSectionTemplate(ctx, 'entity');
+      // No Entity Page Template in body — fall back to canonical entity sections
+      expect(tpl).toContain('## Basic Information');
+    });
+  });
+});

--- a/src/__tests__/ui/settings-tag-desc.test.ts
+++ b/src/__tests__/ui/settings-tag-desc.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+
+// v1.21.0 Phase 1.4: Settings description drift — Default mode should
+// preview user-defined custom tags if the user has typed them, so the
+// description matches the runtime behavior.
+
+describe('settings UI — tag vocabulary description alignment', () => {
+  // Helper that mirrors the production defaultListDesc/effectiveListDesc logic
+  // from settings.ts:720-734. If this drifts, the test will fail.
+  function effectiveListDesc(customEntityTags: string, customConceptTags: string, tagVocabularyMode: string): string {
+    const VALID_ENTITY_TAGS = ['person', 'organization', 'project', 'product', 'event', 'place', 'other'];
+    const VALID_CONCEPT_TAGS = ['theory', 'method', 'field', 'phenomenon', 'standard', 'term', 'other'];
+    const customEntities = customEntityTags.trim();
+    const customConcepts = customConceptTags.trim();
+    const hasCustomInput = customEntities.length > 0 || customConcepts.length > 0;
+    // Effective list shows user values whenever they've been typed,
+    // regardless of mode. The activation hint clarifies if the mode hasn't
+    // been switched yet.
+    const effectiveEntityTags = customEntities.length > 0
+      ? customEntities.split(',').map(t => t.trim()).filter(Boolean)
+      : VALID_ENTITY_TAGS;
+    const effectiveConceptTags = customConcepts.length > 0
+      ? customConcepts.split(',').map(t => t.trim()).filter(Boolean)
+      : VALID_CONCEPT_TAGS;
+    if (hasCustomInput) {
+      const previewNote = tagVocabularyMode === 'default' ? ' — custom values shown above (toggle to Custom to activate)' : '';
+      return `${effectiveEntityTags.join(', ')} (entities) / ${effectiveConceptTags.join(', ')} (concepts)${previewNote}`;
+    }
+    return `${VALID_ENTITY_TAGS.join(', ')} (entities) / ${VALID_CONCEPT_TAGS.join(', ')} (concepts)`;
+  }
+
+  it('Default mode with no custom input: shows built-in defaults', () => {
+    const desc = effectiveListDesc('', '', 'default');
+    expect(desc).toContain('person');
+    expect(desc).toContain('theory');
+    expect(desc).not.toContain('custom values');
+  });
+
+  it('Custom mode with user input: shows user values', () => {
+    const desc = effectiveListDesc('Kardiologie, Immunologie', 'Medizin', 'custom');
+    expect(desc).toContain('Kardiologie');
+    expect(desc).toContain('Medizin');
+    expect(desc).not.toContain('person'); // built-in replaced
+    expect(desc).not.toContain('custom values');
+  });
+
+  it('Default mode WITH user input but NOT in custom mode: previews user values + activation hint', () => {
+    // User typed custom tags but hasn't toggled to Custom yet — show them as preview
+    const desc = effectiveListDesc('Kardiologie, Neurologie', '', 'default');
+    expect(desc).toContain('Kardiologie');
+    expect(desc).toContain('custom values shown above');
+    expect(desc).toContain('toggle to Custom to activate');
+  });
+});

--- a/src/__tests__/wiki/system-prompts-tag-vocab.test.ts
+++ b/src/__tests__/wiki/system-prompts-tag-vocab.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { buildSystemPrompt } from '../../wiki/system-prompts';
+import type { LLMWikiSettings } from '../../types';
+
+// Issue #85 v6 / Phase 1.3: buildSystemPrompt should inject the active tag
+// vocabulary section so user-defined Custom tags are respected by all
+// ingestion paths, not just lint paths.
+
+function makeSettings(overrides: Partial<LLMWikiSettings> = {}): LLMWikiSettings {
+  return {
+    wikiFolder: 'wiki',
+    wikiLanguage: 'en',
+    extractionGranularity: 'standard',
+    customEntityTags: '',
+    customConceptTags: '',
+    tagVocabularyMode: 'default',
+    ...overrides,
+  } as LLMWikiSettings;
+}
+
+describe('buildSystemPrompt — tag vocabulary injection (Phase 1.3)', () => {
+  it('includes tag vocabulary section in default mode', async () => {
+    const settings = makeSettings();
+    const prompt = await buildSystemPrompt(settings, async () => undefined, 'entity');
+    expect(prompt).toBeDefined();
+    expect(prompt).toContain('Active Tag Vocabulary');
+    expect(prompt).toContain('Entity types');
+    expect(prompt).toContain('Concept types');
+    // Default mode should include built-in tags
+    expect(prompt).toContain('person');
+    expect(prompt).toContain('theory');
+  });
+
+  it('includes user-defined custom tags when tagVocabularyMode=custom', async () => {
+    const settings = makeSettings({
+      tagVocabularyMode: 'custom',
+      customEntityTags: 'Kardiologie, Immunologie, Neurologie',
+      customConceptTags: 'Medizin, Diagnostik',
+    });
+    const prompt = await buildSystemPrompt(settings, async () => undefined, 'entity');
+    expect(prompt).toBeDefined();
+    expect(prompt).toContain('Kardiologie');
+    expect(prompt).toContain('Immunologie');
+    expect(prompt).toContain('Neurologie');
+    expect(prompt).toContain('Medizin');
+  });
+
+  it('does NOT include duplicate tag vocab section when already present', async () => {
+    // Defensive: if caller already prepended the section, don't double up.
+    const settings = makeSettings();
+    const prompt = await buildSystemPrompt(
+      settings,
+      async () => 'PREVIOUS TAG VOCAB SECTION',
+      'entity'
+    );
+    // Count occurrences of "Active Tag Vocabulary"
+    const matches = (prompt ?? '').match(/Active Tag Vocabulary/g);
+    expect(matches?.length).toBe(1);
+  });
+
+  it('returns prompt even when schemaContext is undefined', async () => {
+    const settings = makeSettings();
+    // No schema context — but tag vocab section should still appear
+    const prompt = await buildSystemPrompt(settings, async () => undefined, 'entity');
+    expect(prompt).toBeDefined();
+    expect(prompt).toContain('Active Tag Vocabulary');
+  });
+});

--- a/src/schema/schema-context.ts
+++ b/src/schema/schema-context.ts
@@ -1,0 +1,215 @@
+// v1.21.0 Phase 1: SchemaContext — shared parsed representation of schema/config.md.
+//
+// Single source of truth for both system prompts (via buildSystemPrompt)
+// and user prompts (via generation.ts). Before this, generation.ts hardcoded
+// section structure that silently overrode user customization in config.md
+// (see Issue #124).
+//
+// Pure function (no IO, no Obsidian deps) — fully testable.
+
+import { buildDefaultSchemaBody } from './schema-manager';
+
+export interface SchemaSection {
+  /** The `## Heading` text, exactly as written in config.md */
+  heading: string;
+  /** Lines under the heading until the next `## ` or EOF */
+  content: string;
+}
+
+export interface SchemaContext {
+  /** Raw body of schema/config.md (or default if missing) */
+  body: string;
+  /** All `## ...` sections in body, in order */
+  sections: SchemaSection[];
+  /** True if body contains sections not present in the built-in default schema.
+   *  Used by prompt-unification logic to decide whether to inject schema-driven
+   *  section structure or fall back to hardcoded templates. */
+  hasUserSections: boolean;
+  /** The page type this context was parsed for ('entity', 'concept', 'source', or any other).
+   *  Currently informational — section filtering is done by the caller via selectSections. */
+  pageType: string;
+}
+
+/** Set of section headings that ship with buildDefaultSchemaBody(). */
+const DEFAULT_SCHEMA_SECTIONS: ReadonlySet<string> = new Set([
+  'Wiki Structure',
+  'Entity Page Template',
+  'Concept Page Template',
+  'Naming Conventions',
+  'Source Page Template',
+  'Date Fields',
+  'Mentions Format',
+  'Content Rules',
+  'Classification Rules',
+  'Multi-Source Merge Rules',
+  'Maintenance Policies',
+]);
+
+/**
+ * Parse a schema/config.md body into a SchemaContext.
+ *
+ * - Empty/whitespace body → empty sections
+ * - Sections are split on `## ` (single space after hash; matches Markdown h2 convention)
+ * - Top-level `# ` title (h1) is preserved in body but excluded from sections
+ *
+ * @param body - Raw schema body (or empty string)
+ * @param pageType - Which page type is requesting context (entity/concept/source/...)
+ * @returns Parsed SchemaContext
+ */
+export function parseSchemaContext(body: string, pageType: string): SchemaContext {
+  const trimmedBody = body ?? '';
+  const sections = parseSections(trimmedBody);
+  const hasUserSections = sections.some(s => !DEFAULT_SCHEMA_SECTIONS.has(s.heading));
+  return {
+    body: trimmedBody,
+    sections,
+    hasUserSections,
+    pageType,
+  };
+}
+
+function parseSections(body: string): SchemaSection[] {
+  if (!body.trim()) return [];
+  const lines = body.split('\n');
+  const result: SchemaSection[] = [];
+  let currentHeading = '';
+  let currentContent: string[] = [];
+
+  for (const line of lines) {
+    // Only h2 (`## `) splits sections. h1 (`# `) is the schema title — skip.
+    if (line.startsWith('## ')) {
+      if (currentHeading) {
+        result.push({ heading: currentHeading, content: currentContent.join('\n').trim() });
+      }
+      currentHeading = line.substring(3).trim();
+      currentContent = [];
+    } else if (currentHeading) {
+      currentContent.push(line);
+    }
+  }
+  // Flush the last section
+  if (currentHeading) {
+    result.push({ heading: currentHeading, content: currentContent.join('\n').trim() });
+  }
+  return result;
+}
+
+// Re-export for callers that need the default-section set
+export const _INTERNAL = { DEFAULT_SCHEMA_SECTIONS };
+
+// Convenience: get default schema body (re-export from schema-manager for one-stop import)
+export { buildDefaultSchemaBody };
+
+// === Section template extraction (v1.21.0 Phase 1.2) ===
+//
+// Issue #124: generation.ts hardcoded section structure that silently overrode
+// user customization in schema/config.md. This function extracts the user's
+// section names from the schema and produces the markdown template the LLM uses.
+//
+// Behavior:
+// - If schema has a `**Sections:**` numbered list under the page-type template,
+//   extract those section names as the template
+// - Otherwise fall back to canonical defaults (no behavior change for default schema)
+// - `hasUserSections === false` always falls back to canonical defaults
+
+/** Canonical section names per page type — used as fallback when user
+ *  hasn't customized their schema, OR when the user's schema has no
+ *  explicit section list. */
+const CANONICAL_SECTIONS: Record<string, string[]> = {
+  entity: [
+    'Basic Information',
+    'Description',
+    'Related Entities',
+    'Related Concepts',
+    'Mentions in Source',
+  ],
+  concept: [
+    'Definition',
+    'Key Characteristics',
+    'Applications',
+    'Related Concepts',
+    'Related Entities',
+    'Mentions in Source',
+  ],
+  source: [
+    'Summary',
+    'Key Points',
+    'Mentioned Pages',
+  ],
+};
+
+const TEMPLATE_HEADINGS: Record<string, string[]> = {
+  entity: ['Entity Page Template'],
+  concept: ['Concept Page Template'],
+  source: ['Source Page Template'],
+};
+
+/**
+ * Build the section template for a given page type from a parsed SchemaContext.
+ *
+ * Strategy:
+ * 1. Find the page-type template section in the schema (e.g. "Entity Page Template")
+ * 2. Look for a `**Sections:**` numbered list under it
+ * 3. Extract the section names from that list
+ * 4. If no explicit list found, fall back to canonical defaults
+ *
+ * Returns a markdown string with each section as a `## Heading` placeholder.
+ * For example: `## Basic Information\n[content]\n\n## Description\n[content]`
+ */
+export function buildSchemaSectionTemplate(ctx: SchemaContext, pageType: string): string {
+  const fallbackSections = CANONICAL_SECTIONS[pageType] ?? [];
+
+  // If user didn't customize (no extra sections), always use canonical defaults.
+  // This guarantees backward compat: default-schema users see no behavior change.
+  if (!ctx.hasUserSections) {
+    return fallbackSections.map(s => `## ${s}`).join('\n\n');
+  }
+
+  // Find the template section for this page type
+  const templateHeadings = TEMPLATE_HEADINGS[pageType] ?? [];
+  let templateContent = '';
+  for (const heading of templateHeadings) {
+    const section = ctx.sections.find(s => s.heading === heading);
+    if (section) {
+      templateContent = section.content;
+      break;
+    }
+  }
+
+  if (!templateContent) {
+    return fallbackSections.map(s => `## ${s}`).join('\n\n');
+  }
+
+  // Extract numbered list under **Sections:**
+  const sectionNames = extractSectionsList(templateContent);
+  if (sectionNames.length === 0) {
+    return fallbackSections.map(s => `## ${s}`).join('\n\n');
+  }
+
+  return sectionNames.map(name => `## ${name}`).join('\n\n');
+}
+
+/**
+ * Parse a numbered list under `**Sections:**` heading.
+ * Matches patterns like:
+ *   1. **Name**: description
+ *   2. **Name** — description
+ *   3. Name
+ */
+function extractSectionsList(content: string): string[] {
+  const lines = content.split('\n');
+  const names: string[] = [];
+  for (const line of lines) {
+    // Match `N. **Name**` or `N. Name` patterns (number followed by period + bold name)
+    const boldMatch = line.match(/^\s*\d+\.\s+\*\*([^*]+?)\*\*/);
+    if (boldMatch && boldMatch[1]) {
+      names.push(boldMatch[1].trim());
+      continue;
+    }
+    const plainMatch = line.match(/^\s*\d+\.\s+([^*\n]+?)(?:\s*[:：—].*)?$/);
+    if (plainMatch && plainMatch[1]) {
+      names.push(plainMatch[1].trim());
+    }
+  }
+  return names;
+}

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -716,13 +716,30 @@ export class LLMWikiSettingTab extends PluginSettingTab {
       }
     };
 
-    // Default-mode desc shows the concrete default list inline.
-    // Custom-mode desc is terse (no defaults — user is configuring).
-    const defaultListDesc = `${VALID_ENTITY_TAGS.join(', ')} (entities) / ${VALID_CONCEPT_TAGS.join(', ')} (concepts)`;
+    // v1.21.0 Phase 1.4: Settings UI description should reflect the active
+    // vocabulary, not just the hardcoded defaults. When the user has typed
+    // custom tags but hasn't yet toggled to Custom mode, show them in the
+    // Default-mode description as a preview (avoids the "settings UI drift"
+    // found in the v1.21.0 Schema audit).
+    const customEntities = (this.tempSettings.customEntityTags ?? '').trim();
+    const customConcepts = (this.tempSettings.customConceptTags ?? '').trim();
+    const hasCustomInput = customEntities.length > 0 || customConcepts.length > 0;
+    // Effective list shows user values whenever they've been typed,
+    // regardless of mode. The activation hint clarifies if the mode
+    // hasn't been switched yet (avoids Settings UI / runtime drift).
+    const effectiveEntityTags = customEntities.length > 0
+      ? customEntities.split(',').map(t => t.trim()).filter(Boolean)
+      : VALID_ENTITY_TAGS;
+    const effectiveConceptTags = customConcepts.length > 0
+      ? customConcepts.split(',').map(t => t.trim()).filter(Boolean)
+      : VALID_CONCEPT_TAGS;
+    const effectiveListDesc = hasCustomInput
+      ? `${effectiveEntityTags.join(', ')} (entities) / ${effectiveConceptTags.join(', ')} (concepts)${this.tempSettings.tagVocabularyMode === 'default' ? ' — custom values shown above (toggle to Custom to activate)' : ''}`
+      : `${VALID_ENTITY_TAGS.join(', ')} (entities) / ${VALID_CONCEPT_TAGS.join(', ')} (concepts)`;
     const leadDesc = this.getText('tagVocabularyInlineDesc');
     const modeDesc = this.tempSettings.tagVocabularyMode === 'custom'
       ? `${leadDesc}\n${this.getText('tagVocabularyModeDescCustom')}`
-      : `${leadDesc}\n${this.getText('tagVocabularyModeDescDefault').replace('{}', defaultListDesc)}`;
+      : `${leadDesc}\n${this.getText('tagVocabularyModeDescDefault').replace('{}', effectiveListDesc)}`;
 
     new Setting(containerEl)
       .setName(this.getText('tagVocabularyModeName'))

--- a/src/wiki/system-prompts.ts
+++ b/src/wiki/system-prompts.ts
@@ -207,6 +207,17 @@ export async function buildSystemPrompt(
   if (langDirective) parts.push(langDirective);
   const schemaContext = await getSchemaContext(task);
   if (schemaContext) parts.push(schemaContext);
+
+  // v1.21.0 Phase 1.3: Inject active tag vocabulary so user-defined Custom
+  // tags are respected by ALL ingestion paths (not just lint). Skip if the
+  // schema context already contains the section (defensive — caller might
+  // have prepended it).
+  const schemaHasTagVocab = schemaContext?.includes('Active Tag Vocabulary') ?? false;
+  if (!schemaHasTagVocab) {
+    const tagVocab = buildActiveTagVocabularySection(settings);
+    if (tagVocab) parts.push(tagVocab);
+  }
+
   return parts.length > 0 ? parts.join('\n\n') : undefined;
 }
 


### PR DESCRIPTION
## Summary

Schema Coherence Phase 1 — the schema becomes the single source of truth for both system prompts and generation prompts. Closes #124 (Generation/merge prompts hardcode page section structure, bypassing the schema Page Template).

## What changed (9 files, +620/-18)

### New pure-function module

- **** (215 lines): `SchemaContext` parsed representation of `schema/config.md`, used by both system prompts and generation prompts. Includes:
  - `parseSchemaContext(body, pageType)` — parses schema/config.md into sections
  - `buildSchemaSectionTemplate(ctx, pageType)` — extracts user-defined sections from `**Sections:**` lists
  - `hasUserSections` flag for backward compat (when schema has no custom sections → fall back to current hardcoded templates)
- **4 new test suites** (301 lines total): `schema-context.test.ts`, `schema-section-template.test.ts`, `settings-tag-desc.test.ts`, `system-prompts-tag-vocab.test.ts`

### Modified wiring

- `src/wiki/system-prompts.ts` — `buildSystemPrompt` now injects tag vocabulary section (was only injected into lint paths before).
- `src/ui/settings.ts` — default-mode description uses `getActiveEntityTags/Concepts` for live alignment (no more hardcoded `VALID_ENTITY_TAGS`).

### Rebased onto current main

This branch was originally based on v1.20.2; rebased onto current main to incorporate:
- **#154/#156/#158** (v1.20.3 hotfix triple)
- **Italian locale** (PR #159)
- **i18n-parity test extension** (PR #166 — bidirectional parity now covers all 9 locales)
- ROADMAP/CLAUDE updates for #164 tracking

Rebase resolved one ROADMAP.md conflict (Next Milestone header was edited on both sides — kept the Schema Phase 1 detailed version, added the #164 tracking line).

## The three bugs this fixes (from code review in #124)

1. **Section structure hardcoded in user prompts.** `src/wiki/prompts/generation.ts` lines 57-70 hardcode `## {{section_basic_information}}`, etc. in the user prompt, while `schema/config.md` templates go into the system prompt. Two conflicting definitions in one LLM call.
2. **Tag vocabulary only injected into lint paths.** `buildActiveTagVocabularySection` was called by lint-analyze and fix-runners, but NOT by `buildSystemPrompt` or `generation.ts`. Users on Custom tag vocabulary see their settings silently ignored for page generation.
3. **Settings UI description drift.** `settings.ts` showed hardcoded `VALID_ENTITY_TAGS` in the default-mode description, but the actual runtime uses `getActiveEntityTags(settings)` which switches to user-defined CSV in Custom mode.

## Acceptance criteria

- ✅ Schema customization in `config.md` propagates to actual generated pages (not silently overridden)
- ✅ Custom tag vocabulary in settings is respected by all ingestion paths
- ✅ Existing wikis (with default schema) produce identical output before and after (backward compat via `hasUserSections` fallback)
- ✅ Tests pass for both default-schema and custom-schema paths (22 new tests)

## Test plan

- [x] `pnpm lint` — 0 errors / 0 warnings
- [x] `npx tsc --noEmit` — 0 errors
- [x] `pnpm test` — **843 passing** (was 821; +22 from Schema Phase 1)
- [x] `pnpm build` — clean exit
- [x] Manual verification: `hasUserSections = false` path uses existing hardcoded templates unchanged

## Related

- Closes #124 (Generation/merge prompts hardcode section structure)
- Lands alongside Italian locale (PR #159) and i18n-parity test extension (PR #166)
- #164 (Empty-content hallucinated entity) is a SEPARATE fix — @Indexed-Apogrypha is opening the PR; will land in same v1.21.0 release but separate PR

## SchemaPhase 1 design rationale

Minimum-invasive + backward compatible:
- Pure-function module (no IO) → trivially unit-testable
- Schema parsing isolated in `SchemaContext` — existing `buildSystemPrompt` and `generation.ts` consume the same parsed shape
- Fallback to current hardcoded templates when schema has no custom sections → zero behavior change for users who haven't customized schema
- All 22 new tests are pure function tests → fast, deterministic, no LLM mocks needed