### PR TITLE
fix(v1.21.0): i18n error message (#172) + dedup createdPages (#173)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,6 +133,10 @@ Release focus: unify schema as the single source of truth for both system prompt
 
 **🔴 #164 — Empty-content hallucinated entity guard** (in PR by @Indexed-Apogrypha). Add early-return in `WikiEngine.ingestSource` (line ~248, right after `vault.read`): if `fileContent.trim().length === 0` → emit `emptySourceNotice` + return. Plus 9-locale i18n + unit + integration tests. Closes a critical bug where local models (Ollama gemma4, qwen-coder) hallucinate entity names from empty input prompts. Folded into v1.21.0 with Schema Phase 1 to avoid two consecutive hotfixes within a week.
 
+- 🔴 **#173 — Ingest: create-retry loop + duplicate Created entry** (reported by @Indexed-Apogrypha 2026-06-21). Symptom A: `createOrUpdateFile()` retries `vault.create()` 3 times when path already exists, instead of short-circuiting to `vault.process()`. Symptom B: `analysis.created_pages` lacks Set dedup, causing duplicate report rows. Both small fixes bundled with #164.
+- 🔴 **#172 — i18n: hardcoded Chinese error string** (reported by @Indexed-Apogrypha 2026-06-21). `wiki-engine.ts:850` throws `无法创建或更新文件: ${path}` unconditionally. Add `fileWriteFailed` i18n key × 9 locales + replace with `getText(...)`. Audit other source files for similar leaks.
+- 🟢 **#170 — Incomplete-page cleaner** (tracked for v1.21.0, design approved 2026-06-21). Simplification: instead of full-batch atomic write, use `generation_complete: false` frontmatter signal flipped to `true` only after full body write. Startup self-scan cleans any pages where signal is missing/false. Preserves write-through simplicity, works with existing AbortController.
+
 ### Phase 2: Custom section names + #97 one-click apply (v1.21.0 or v1.22.0)
 
 - Schema supports custom section names (not just multi-language translation)
@@ -145,6 +149,9 @@ Release focus: unify schema as the single source of truth for both system prompt
 - **#117 — Graph-based domain tag inference.** Hub detection + cheap LLM labeling + tag propagation with explainability.
 - **#122 — Ingestion history panel.** Start with log.md UI layer.
 - **#130 — In-place batch ingest queue.** Composes with #122 and `pageGenerationConcurrency`.
+- **#168 — Single-file vs batch granularity split** (design approved 2026-06-21). Replace single `extractionGranularity` with two independent settings: `singleFileGranularity` + `batchGranularity`. Rationale: single-file ingest is pre-vetted (expects depth), folder ingest is bulk (expects noise reduction).
+- **#169 — Better status reporting** (deferred split scope). Phase 1 (v1.22.0): richer progress text (batch count, ETA, current model). Phase 2 (backlog): live file preview (needs new UI component).
+- **#157 — Embedding-distinctiveness hub-link policy** (DocTpoint proposal). Replace tag-based stripping with cosine-based distinctiveness. Opt-in via `hubLinkPolicy: 'embedding'` mode. 252-link empirical evidence on bge-m3.
 
 ### Out of scope (v1.21.0+)
 

--- a/src/__tests__/wiki/wiki-engine-dedup.test.ts
+++ b/src/__tests__/wiki/wiki-engine-dedup.test.ts
@@ -1,0 +1,29 @@
+// Helper extracted to dedup page paths before reporting (#173 Symptom B).
+// Pure: input order is preserved, only exact-string duplicates are collapsed.
+
+import { describe, it, expect } from 'vitest';
+import { dedupPages } from '../../wiki/wiki-engine';
+
+describe('dedupPages (#173 Symptom B)', () => {
+  it('preserves order and drops exact-string duplicates', () => {
+    expect(
+      dedupPages([
+        'wiki/entities/alpha.md',
+        'wiki/entities/beta.md',
+        'wiki/entities/alpha.md',
+      ])
+    ).toEqual(['wiki/entities/alpha.md', 'wiki/entities/beta.md']);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(dedupPages([])).toEqual([]);
+  });
+
+  it('returns the same array (deduped) when no duplicates exist', () => {
+    expect(dedupPages(['a', 'b', 'c'])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('collapses many identical entries to one', () => {
+    expect(dedupPages(['x', 'x', 'x', 'x'])).toEqual(['x']);
+  });
+});

--- a/src/__tests__/wiki/wiki-engine-i18n-error.test.ts
+++ b/src/__tests__/wiki/wiki-engine-i18n-error.test.ts
@@ -1,0 +1,57 @@
+// Issue #172 — `createOrUpdateFile()` final-fallback error must come from i18n,
+// never a hardcoded CJK string. Pure unit test: mock the vault so every write
+// path fails, then assert the thrown message contains the localized label and
+// the file path — and NOT any raw Chinese characters.
+
+import { describe, it, expect, vi } from 'vitest';
+import { WikiEngine } from '../../wiki/wiki-engine';
+import { createMockClient } from '../__support__/engine-context';
+
+// Build a WikiEngine whose vault always rejects writes.
+function buildAlwaysFailingEngine() {
+  const failingVault = {
+    read: async () => '',
+    getAbstractFileByPath: () => null,
+    getMarkdownFiles: () => [],
+    create: vi.fn(async () => { throw new Error('File already exists'); }),
+    process: vi.fn(async () => { throw new Error('File already exists'); }),
+    modify: vi.fn(async () => { throw new Error('File already exists'); }),
+    createFolder: async () => {},
+    getFiles: () => [],
+  };
+
+  const app = { vault: failingVault } as unknown as ConstructorParameters<typeof WikiEngine>[0];
+  const settings = {
+    wikiFolder: 'wiki',
+    language: 'en',
+    llmReady: true,
+  } as unknown as ConstructorParameters<typeof WikiEngine>[1];
+  const client = createMockClient(['{"entities":[],"concepts":[]}']);
+
+  const engine = new WikiEngine(
+    app,
+    settings,
+    () => client,
+    { ensureSchemaExists: async () => {}, getSchemaContext: async () => '' } as never,
+    () => {},
+    () => {},
+    () => {}
+  );
+
+  return { engine, failingVault };
+}
+
+describe('WikiEngine.createOrUpdateFile — i18n error (#172)', () => {
+  it('throws a localized message instead of the hardcoded CJK string', async () => {
+    const { engine } = buildAlwaysFailingEngine();
+
+    await expect(engine.createOrUpdateFile('wiki/entities/foo.md', '# Body')).rejects.toThrow(
+      /Could not create or update file/i
+    );
+
+    await expect(engine.createOrUpdateFile('wiki/entities/foo.md', '# Body')).rejects.not.toThrow(
+      // Belt-and-suspenders: explicitly fail if the literal CJK string leaks.
+      /无法创建或更新文件/
+    );
+  });
+});

--- a/src/texts/de.ts
+++ b/src/texts/de.ts
@@ -154,6 +154,7 @@ export const DE_TEXTS = {
     errorLLMClientNotInit: 'LLM-Client nicht initialisiert. Bitte Einstellungen speichern.',
     errorIngestFailed: 'Aufnahme fehlgeschlagen: ',
     errorQueryFailed: 'Anfrage fehlgeschlagen: ',
+    fileWriteFailed: 'Datei konnte nicht erstellt oder aktualisiert werden: {path}',
 
     // Success Messages
     ingestSuccess: 'Aufnahme erfolgreich: {} Seiten erstellt, {} Seiten aktualisiert',

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -166,6 +166,7 @@ export const EN_TEXTS = {
     errorLLMClientNotInit: 'LLM Client not initialized. Please save settings.',
     errorIngestFailed: 'Ingest failed: ',
     errorQueryFailed: 'Query failed: ',
+    fileWriteFailed: 'Could not create or update file: {path}',
 
     // Success Messages
     ingestSuccess: 'Ingest successful: {} pages created, {} pages updated',

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -154,6 +154,7 @@ export const ES_TEXTS = {
     errorLLMClientNotInit: 'Cliente LLM no inicializado. Guarda la configuración.',
     errorIngestFailed: 'La ingestión falló: ',
     errorQueryFailed: 'La consulta falló: ',
+    fileWriteFailed: 'No se pudo crear ni actualizar el archivo: {path}',
 
     // Success Messages
     ingestSuccess: 'Ingestión completada: {} páginas creadas, {} páginas actualizadas',

--- a/src/texts/fr.ts
+++ b/src/texts/fr.ts
@@ -154,6 +154,7 @@ export const FR_TEXTS = {
     errorLLMClientNotInit: 'Client LLM non initialisé. Veuillez enregistrer les paramètres.',
     errorIngestFailed: "Échec de l'import : ",
     errorQueryFailed: 'Échec de la requête : ',
+    fileWriteFailed: "Impossible de créer ou de mettre à jour le fichier : {path}",
 
     // Success Messages
     ingestSuccess: 'Import réussi : {} pages créées, {} pages mises à jour',

--- a/src/texts/it.ts
+++ b/src/texts/it.ts
@@ -166,6 +166,7 @@ export const IT_TEXTS = {
     errorLLMClientNotInit: 'Client LLM non inizializzato. Salva le impostazioni.',
     errorIngestFailed: 'Acquisizione fallita: ',
     errorQueryFailed: 'Query fallita: ',
+    fileWriteFailed: 'Impossibile creare o aggiornare il file: {path}',
 
     // Messaggi di successo
     ingestSuccess: 'Acquisizione riuscita: {} pagine create, {} pagine aggiornate',

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -154,6 +154,7 @@ export const JA_TEXTS = {
     errorLLMClientNotInit: 'LLM Clientが初期化されていません。設定を保存してください。',
     errorIngestFailed: '取り込み失敗：',
     errorQueryFailed: '問い合わせ失敗：',
+    fileWriteFailed: 'ファイルを作成または更新できません：{path}',
 
     // Success Messages
     ingestSuccess: '取り込み成功：{}ページ作成、{}ページ更新',

--- a/src/texts/ko.ts
+++ b/src/texts/ko.ts
@@ -155,6 +155,7 @@ export const KO_TEXTS = {
     errorLLMClientNotInit: 'LLM 클라이언트가 초기화되지 않았습니다. 설정을 저장하세요.',
     errorIngestFailed: '수집 실패: ',
     errorQueryFailed: '질의 실패: ',
+    fileWriteFailed: '파일을 만들거나 업데이트할 수 없습니다: {path}',
 
     // Success Messages
     ingestSuccess: '수집 완료: {} 페이지 생성, {} 페이지 업데이트',

--- a/src/texts/pt.ts
+++ b/src/texts/pt.ts
@@ -154,6 +154,7 @@ export const PT_TEXTS = {
     errorLLMClientNotInit: 'LLM Client não inicializado. Salve as configurações.',
     errorIngestFailed: 'Falha na ingestão: ',
     errorQueryFailed: 'Falha na consulta: ',
+    fileWriteFailed: 'Não foi possível criar ou atualizar o ficheiro: {path}',
 
     // Success Messages
     ingestSuccess: 'Ingestão bem-sucedida: {} páginas criadas, {} páginas atualizadas',

--- a/src/texts/zh.ts
+++ b/src/texts/zh.ts
@@ -155,6 +155,7 @@ export const ZH_TEXTS = {
     errorLLMClientNotInit: 'LLM Client 未初始化。请保存设置。',
     errorIngestFailed: '摄入失败：',
     errorQueryFailed: '查询失败：',
+    fileWriteFailed: '无法创建或更新文件：{path}',
 
     // 成功消息
     ingestSuccess: '摄入成功：创建{}页，更新{}页',

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -41,6 +41,24 @@ import { TOKENS_PAGE_GENERATION, NOTICE_ABORT, NOTICE_RATE_LIMIT, NOTICE_NORMAL,
 import { PageFactory } from './page-factory';
 import { ConversationIngestor, ConversationOrchestration, formatConversation, ConversationHistory } from './conversation-ingest';
 
+/**
+ * Issue #173 Symptom B: drop exact-string duplicates from a page-path list
+ * while preserving first-occurrence order. Used to dedup `analysis.created_pages`
+ * before assembling the IngestReport so a duplicate surface-form (e.g. two
+ * "intelligent-xtraction-and-processing" entries from one batch) does not
+ * inflate the report count or the "Created" listing.
+ */
+export function dedupPages(paths: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const p of paths) {
+    if (seen.has(p)) continue;
+    seen.add(p);
+    out.push(p);
+  }
+  return out;
+}
+
 export class WikiEngine {
   private app: App;
   settings: LLMWikiSettings;
@@ -557,15 +575,18 @@ export class WikiEngine {
       const indexTime = Date.now() - indexStart;
       console.debug(`[Time] Index Index & log update: ${indexTime}ms`);
 
-      const created = analysis.created_pages.length;
       const updated = analysis.updated_pages.length;
-      const entitiesCreated = analysis.created_pages.filter(p => p.includes('/entities/')).length;
-      const conceptsCreated = analysis.created_pages.filter(p => p.includes('/concepts/')).length;
+      // Issue #173 Symptom B: dedup before counting/listing — a duplicated
+      // surface-form (e.g. the LLM emitting the same path twice) must not
+      // inflate the report count or the "Created" listing.
+      const dedupedCreatedPages = dedupPages(analysis.created_pages);
+      const entitiesCreated = dedupedCreatedPages.filter(p => p.includes('/entities/')).length;
+      const conceptsCreated = dedupedCreatedPages.filter(p => p.includes('/concepts/')).length;
       const modeLabel = (this.settings.pageGenerationConcurrency ?? 1) > 1 ? `parallel(concurrency:${this.settings.pageGenerationConcurrency})` : 'serial';
       // totalTime was computed above; do not redeclare here.
 
       console.debug('=== Ingestion complete ===');
-      console.debug(`Ingestion complete [${modeLabel}]: Created ${created} pages (${entitiesCreated} entities + ${conceptsCreated} concepts), Updated ${updated} pages, ${collisions.length} cross-type collisions`);
+      console.debug(`Ingestion complete [${modeLabel}]: Created ${dedupedCreatedPages.length} pages (${entitiesCreated} entities + ${conceptsCreated} concepts), Updated ${updated} pages, ${collisions.length} cross-type collisions`);
       console.debug(`[Total time] ${totalTime}ms (${Math.round(totalTime/1000)}s)`);
       console.debug('[Phase breakdown]:');
       console.debug(`  - Source analysis: ${analysisTime}ms`);
@@ -583,7 +604,7 @@ export class WikiEngine {
 
       this.onDone?.({
         sourceFile: file.path,
-        createdPages: analysis.created_pages,
+        createdPages: dedupedCreatedPages,
         updatedPages: analysis.updated_pages,
         entitiesCreated,
         conceptsCreated,
@@ -595,7 +616,7 @@ export class WikiEngine {
       });
 
     } catch (error) {
-      const createdPages = analysis?.created_pages || [];
+      const createdPages = dedupPages(analysis?.created_pages || []);
 
       if (error instanceof DOMException && error.name === 'AbortError') {
         this.wasCancelled = true;
@@ -847,7 +868,10 @@ export class WikiEngine {
       this.onFileWrite?.(path);
       this.pagesCache = null;
     } else {
-      throw new Error(`无法创建或更新文件: ${path}`);
+      // Issue #172: localize via getText, never hardcode CJK in source.
+      throw new Error(
+        getText(this.settings.language, 'fileWriteFailed').replace('{path}', path)
+      );
     }
   }
 
@@ -1081,7 +1105,7 @@ export class WikiEngine {
       ? this.formatIngestMetricsSuffix(metrics)
       : '';
     let entry = `\n\n## [${date} ${time}] ${operation} | ${analysis.source_title}${h2Suffix}\n\n`;
-    entry += `**${labels.createdPages}**：${analysis.created_pages.map(p => `[[${p.replace(this.settings.wikiFolder + '/', '')}]]`).join(', ')}\n\n`;
+    entry += `**${labels.createdPages}**：${dedupPages(analysis.created_pages).map(p => `[[${p.replace(this.settings.wikiFolder + '/', '')}]]`).join(', ')}\n\n`;
     entry += `**${labels.updatedPages}**：${analysis.updated_pages.map(p => `[[${p}]]`).join(', ')}\n\n`;
 
     if (analysis.contradictions.length > 0) {


### PR DESCRIPTION
## Summary

Two small bug fixes from the #164 testing triage (2026-06-21).

### #172 — Hardcoded Chinese error string leaks into non-Chinese UI

`WikiEngine.createOrUpdateFile()` threw a literal `无法创建或更新文件: ${path}` when all write paths failed. Non-Chinese users saw raw CJK in the "⚠️ Failed to ingest" section of the Ingest report.

**Fix:** New `fileWriteFailed` i18n key across all 9 locales + `getText()` call replacing the hardcoded throw.

**Affected:** `src/wiki/wiki-engine.ts:871`, 9 × `src/texts/*.ts`.

### #173 Symptom B — Duplicate entry in `createdPages` inflates report count

The Ingest report "Created" listing and count header did not dedup `analysis.created_pages`. A duplicated surface-form (LLM emitting the same path twice in one batch) inflated both the count and the listing.

**Fix:** New `dedupPages()` pure-function helper (first-occurrence Set) applied at the three report sites: onDone success path, onDone error path, and log entry.

**Affected:** `src/wiki/wiki-engine.ts` (3 dedup points), new `dedupPages` export.

> Note: #173 Symptom A (create-retry loop when alias resolution collides with an existing path) is a separate fix in `page-factory.ts`/`resolvePagePath` — out of scope for this PR.

## Tests

- `wiki-engine-dedup.test.ts` — 4 cases (ordering, empty, no-dup, heavy-dup)
- `wiki-engine-i18n-error.test.ts` — 1 case (mock-vault always-fails engine → asserts thrown message is `Could not create or update file` NOT `无法创建`)

**897 passing** (was 892, +5 new).

## Gate 4: Performance

| Dim | Status | Notes |
|-----|--------|-------|
| CPU | ✅ | `dedupPages` is O(n) Set scan — negligible |
| Memory | ✅ | One extra Set per ingest, max ~20 entries |
| IO | ✅ | No new vault reads |
| Network | ✅ | No LLM calls |
| Token | ✅ | N/A |

Closes #172, #173

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>