### PR TITLE
feat: show document name and batch progress in ingest status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Ingestion status bar now shows the current document name.** Single-file ingest displays `<doc> · Ingesting... click to cancel` instead of the bare label, so the active source is visible at a glance.
+- **Folder batch ingest surfaces progress in the status bar.** During a folder batch run the status bar shows `[current/total] <doc> · Ingesting... click to cancel` (e.g. `[4/10] My Note · Ingesting... click to cancel`), mirroring the existing progress Notice. New pure-function `core/status-bar.ts` (`buildIngestStatusBarText`) composes the text from the existing localized label — no new i18n keys, all 9 locales covered automatically. The `WikiEngine` ingestion-start callback now passes the source basename (optional param, backward-compatible).
+
+### Tests
+- New `core/status-bar` suite (7 tests) for single/batch/empty composition. **948 tests passing** (was 941 in v1.21.1; +7).
+
 ## [1.21.1] - 2026-06-22
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,14 @@
 # LLM Wiki Plugin Project Development Standards
 
-**Last Updated:** 2026-06-22
+**Last Updated:** 2026-06-22 (ingest status bar UX)
 
 ---
 
 ## Current Phase: v1.21.1 Released — v1.22.0 Schema Phase 2 (planned)
+
+### Completed (Unreleased) — Ingest status bar UX 2026-06-22
+- ✅ **Ingest status bar shows document name + batch progress.** Single-file ingest now shows `<doc> · Ingesting...`; folder batch ingest shows `[current/total] <doc> · Ingesting... click to cancel`. New pure-function `core/status-bar.ts` (`buildIngestStatusBarText`) composes from the existing localized label — no new i18n keys. `WikiEngine` ingestion-start callback passes the source basename (optional param, backward-compatible). `batchProgress` field in `main.ts` tracks loop position.
+- ✅ **Tests: 948 passing.** +7 (`core/status-bar` suite).
 
 ### Completed (v1.21.1) — Hotfix 2026-06-22
 - ✅ **#173 Symptom A — createOrUpdateFile create-retry loop.** NFC/NFD path resolution before `vault.create`.
@@ -146,8 +150,9 @@ src/
 │   ├── convergence-detector.ts     # Early-stop on low-yield batches
 │   ├── sse-parser.ts               # SSE event parser (anthropic + openai formats)
 │   ├── token-cap.ts                # max_tokens cap helper
+│   ├── status-bar.ts               # Ingest status bar text composition (name + batch progress)
 │   └── conflict-resolver.ts        # Conflict detection
-└── __tests__/                      # Unit tests (vitest, 941 tests)
+└── __tests__/                      # Unit tests (vitest, 948 tests)
 ```
 
 ---

--- a/src/__tests__/core/status-bar.test.ts
+++ b/src/__tests__/core/status-bar.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { buildIngestStatusBarText } from '../../core/status-bar';
+
+const LABEL = '提取中... 点击取消';
+
+describe('buildIngestStatusBarText', () => {
+  it('returns the bare label when no filename and no batch info', () => {
+    expect(buildIngestStatusBarText(LABEL)).toBe(LABEL);
+  });
+
+  it('prefixes the filename before the label for a single file', () => {
+    expect(buildIngestStatusBarText(LABEL, 'My Note')).toBe('My Note · 提取中... 点击取消');
+  });
+
+  it('prefixes the batch counter and filename when batch info is given', () => {
+    expect(buildIngestStatusBarText(LABEL, 'My Note', { current: 4, total: 10 })).toBe(
+      '[4/10] My Note · 提取中... 点击取消'
+    );
+  });
+
+  it('shows the batch counter alone when batch info is given but filename is missing', () => {
+    expect(buildIngestStatusBarText(LABEL, undefined, { current: 2, total: 5 })).toBe(
+      '[2/5] 提取中... 点击取消'
+    );
+  });
+
+  it('falls back to the bare label when filename is empty/whitespace and no batch', () => {
+    expect(buildIngestStatusBarText(LABEL, '   ')).toBe(LABEL);
+  });
+
+  it('trims the filename', () => {
+    expect(buildIngestStatusBarText(LABEL, '  Note  ')).toBe('Note · 提取中... 点击取消');
+  });
+
+  it('ignores null batch info', () => {
+    expect(buildIngestStatusBarText(LABEL, 'Doc', null)).toBe('Doc · 提取中... 点击取消');
+  });
+});

--- a/src/core/status-bar.ts
+++ b/src/core/status-bar.ts
@@ -1,0 +1,28 @@
+/**
+ * Status bar text composition for ingestion progress.
+ *
+ * Pure functions — zero IO. Composes the existing localized status-bar label
+ * (e.g. "提取中... 点击取消") with the current document name and, during a
+ * folder batch run, the [current/total] counter.
+ *
+ * Examples (label = "提取中... 点击取消"):
+ *   single:  "My Note · 提取中... 点击取消"
+ *   batch:   "[4/10] My Note · 提取中... 点击取消"
+ *   no info: "提取中... 点击取消"  (backward-compatible fallback)
+ */
+
+export interface BatchProgress {
+  current: number;
+  total: number;
+}
+
+export function buildIngestStatusBarText(
+  label: string,
+  filename?: string,
+  batch?: BatchProgress | null
+): string {
+  const name = filename?.trim() || '';
+  const prefix = batch ? `[${batch.current}/${batch.total}] ` : '';
+  const body = name ? `${name} · ${label}` : label;
+  return `${prefix}${body}`;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,6 +82,7 @@ import { getText } from './core/i18n';
 import { slugify } from './core/slug';
 import { parseFrontmatter } from './core/frontmatter';
 import { normalizeVocabularyCsv } from './core/tag-vocab';
+import { buildIngestStatusBarText, BatchProgress } from './core/status-bar';
 import { LLMWikiSettingTab } from './ui/settings';
 import { WikiEngine } from './wiki/wiki-engine';
 import { QueryModal } from './wiki/query-engine';
@@ -99,6 +100,9 @@ export default class LLMWikiPlugin extends Plugin {
   autoMaintainManager: AutoMaintainManager;
   private progressNotice: Notice | null = null;
   private ingestStatusBar: HTMLElement | null = null;
+  // Tracks the current document position during a folder batch ingest so the
+  // status bar can show "[current/total] <doc> · …". Null for single-file ingest.
+  private batchProgress: BatchProgress | null = null;
 
   async onload() {
     await this.loadSettings();
@@ -251,10 +255,12 @@ export default class LLMWikiPlugin extends Plugin {
     };
 
     this.wikiEngine.setIngestionCallbacks(
-      () => {
+      (filename?: string) => {
         const label = getText(this.settings.language, 'ingestionStatusBar');
         if (this.ingestStatusBar) {
-          this.ingestStatusBar.setText(label);
+          this.ingestStatusBar.setText(
+            buildIngestStatusBarText(label, filename, this.batchProgress)
+          );
           this.ingestStatusBar.removeClass('llm-wiki-status-bar-hidden');
         }
       },
@@ -564,6 +570,7 @@ export default class LLMWikiPlugin extends Plugin {
         const file = newFiles[i];
 
         try {
+          this.batchProgress = { current: i + 1, total: ingestCount };
           this.showProgress(`[${i + 1}/${ingestCount}] ${file.basename}`);
           console.debug(`(${i + 1}/${ingestCount}) ingesting: ${file.path}`);
           await this.wikiEngine.ingestSource(file, { batchCtx });
@@ -579,6 +586,7 @@ export default class LLMWikiPlugin extends Plugin {
         }
       }
 
+      this.batchProgress = null;
       this.wikiEngine.setDoneCallback((report: IngestReport) => this.onIngestDone(report));
 
       this.dismissProgress();

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -87,7 +87,7 @@ export class WikiEngine {
   private abortController: AbortController | null = null;
   private lintAbortController: AbortController | null = null;
   wasCancelled = false;
-  private onIngestionStart: (() => void) | null = null;
+  private onIngestionStart: ((filename?: string) => void) | null = null;
   private onIngestionEnd: (() => void) | null = null;
   private onLintStart: (() => void) | null = null;
   private onLintEnd: (() => void) | null = null;
@@ -205,7 +205,7 @@ export class WikiEngine {
     this.onDone = cb;
   }
 
-  setIngestionCallbacks(onStart: (() => void) | null, onEnd: (() => void) | null): void {
+  setIngestionCallbacks(onStart: ((filename?: string) => void) | null, onEnd: (() => void) | null): void {
     this.onIngestionStart = onStart;
     this.onIngestionEnd = onEnd;
   }
@@ -410,7 +410,7 @@ export class WikiEngine {
     // Setup cancellation support
     this.wasCancelled = false;
     this.abortController = new AbortController();
-    this.onIngestionStart?.();
+    this.onIngestionStart?.(file.basename);
 
     // Long-source warning: large files trigger iterative batch extraction
     // (multiple LLM passes), which takes significantly longer than small files.


### PR DESCRIPTION
Single-file ingest now shows "<doc> · Ingesting... click to cancel" instead of the bare label, and folder batch ingest shows "[current/total] <doc> · Ingesting... click to cancel".

demo:
<img width="608" height="132" alt="image" src="https://github.com/user-attachments/assets/88ba0751-220b-4956-8549-ead4cf7294aa" />


- New pure-function core/status-bar.ts (buildIngestStatusBarText) composes the text from the existing localized ingestionStatusBar label — no new i18n keys, all 9 locales covered automatically.
- WikiEngine ingestion-start callback now passes the source basename (optional param, backward-compatible).
- main.ts tracks loop position via a batchProgress field, set per iteration in the folder loop and reset after.
- 7 new core/status-bar tests; 948 tests passing (was 941).
