### PR TITLE
fix: #186 appendAliases regex + #188 merge.ts hardcoded English headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **#189 — Ingest status bar shows document name + batch progress (PR by @YounianC).** Single-file ingest displays `<doc> · Ingesting... click to cancel` instead of the bare label. Folder batch ingest shows `[current/total] <doc> · Ingesting... click to cancel`. New pure-function `core/status-bar.ts` (`buildIngestStatusBarText`) composes from the existing localized `ingestionStatusBar` label — no new i18n keys, all 10 locales covered automatically. `WikiEngine` ingestion-start callback now passes the source basename (optional param, backward-compatible). `batchProgress` field in `main.ts` tracks loop position.
 
 ### Fixed
+- **`merge.ts` hardcoded English section headers (#188).** Both `mergeEntityPage` and `mergeConceptPage` prompt templates used hardcoded `## Related Entities` / `## Related Concepts` / `## Basic Information` / `## Description` / `## Mentions in Source` headers, ignoring the configured `wikiLanguage`. Replaced with `{{section_*}}` placeholders so `applySectionLabels()` localizes them consistently across create and merge paths. Non-English vaults no longer get mixed-language section headers.
+- **`appendAliases` block-replace regex left stale items (#186).** `page-factory.ts:70` regex `/^aliases:[\s\S]*?(?=\n\S|\n*$)/m` — the `m` flag caused `$` to match end-of-line, so the lookahead succeeded immediately and the lazy quantifier matched zero characters. Only the bare `aliases:` line was replaced; existing list items survived, producing duplicate entries on every subsequent append. Fixed with `/^aliases:[^\n]*(?:\n[ \t]+[^\n]*)*/m` which consumes continuation lines by indentation.
 - **Lint: `apply-suggestion.ts` used `vault.delete()` fallback.** Simplified to direct `app.fileManager.trashFile` call — respects user's file deletion preference per Obsidian review rule `obsidianmd/prefer-file-manager-trash-file`. Test mock updated accordingly.
 - **Lint: `parse-suggestion.ts` unnecessary type assertion.** `as LLMSchemaResponse` cast removed (receiver already accepts the original type).
 
 ### Tests
-- **1003 tests passing** (was 948 in v1.21.1; +55: schema suite 48 tests + status-bar suite 7 tests).
+- **1006 tests passing** (was 948 in v1.21.1; +58: schema suite 48 tests + status-bar suite 7 tests + #186/#188 regression tests 3 tests).
 
 ## [1.21.1] - 2026-06-22
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ src/
 │   ├── backup-rotation.ts          # Backup file rotation (MAX_BACKUPS=3)
 │   ├── detail-renderer.ts          # Detail block rendering
 │   └── conflict-resolver.ts        # Conflict detection
-└── __tests__/                      # Unit tests (vitest, 1003 tests)
+└── __tests__/                      # Unit tests (vitest, 1006 tests)
 ```
 
 ---

--- a/src/__tests__/wiki/page-factory.test.ts
+++ b/src/__tests__/wiki/page-factory.test.ts
@@ -87,6 +87,30 @@ describe('PageFactory — appendAliases', () => {
     const content = page(vault, 'wiki/entities/nonexistent.md');
     expect(content).toBeNull();
   });
+
+  // #186: block-format existing aliases must be fully replaced, not left as stale items
+  it('replaces existing block-format aliases without leaving stale items', async () => {
+    const { factory, vault } = makeFactory({
+      'wiki/entities/test.md': '---\ntype: entity\naliases:\n  - "Executive Function"\n  - "Exekutive Funktionen"\n---\n# Test\nBody',
+    });
+    await appendAliases(factory, 'wiki/entities/test.md', ['Working Memory']);
+
+    const content = page(vault, 'wiki/entities/test.md');
+    expect(content).not.toBeNull();
+    // New alias must be present
+    expect(content!).toContain('"Working Memory"');
+    // Old aliases must be preserved (append, not replace)
+    expect(content!).toContain('"Executive Function"');
+    expect(content!).toContain('"Exekutive Funktionen"');
+    // Each alias must appear exactly once — no stale duplicates from block-replace bug
+    const execMatches = content!.match(/"Executive Function"/g);
+    expect(execMatches).toHaveLength(1);
+    const exekMatches = content!.match(/"Exekutive Funktionen"/g);
+    expect(exekMatches).toHaveLength(1);
+    // Only one aliases: key
+    const aliasesKeyMatches = content!.match(/^aliases:/gm);
+    expect(aliasesKeyMatches).toHaveLength(1);
+  });
 });
 
 describe('PageFactory — buildPagesListForPrompt', () => {

--- a/src/__tests__/wiki/prompts/prompt-hardcode.test.ts
+++ b/src/__tests__/wiki/prompts/prompt-hardcode.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { INGESTION_PROMPTS } from '../../../wiki/prompts/ingestion';
 import { LINT_PROMPTS } from '../../../wiki/prompts/lint';
 import { FIX_PROMPTS } from '../../../wiki/prompts/fixes';
+import { MERGE_PROMPTS } from '../../../wiki/prompts/merge';
 
 describe('Prompt templates — no hardcoded wiki/ paths', () => {
   it('resolveEntityDedup uses {{wikiFolder}} placeholder for example path', () => {
@@ -29,5 +30,27 @@ describe('Prompt templates — no hardcoded wiki/ paths', () => {
     const tpl = FIX_PROMPTS.linkOrphanPage;
     expect(tpl).not.toContain('"wiki/entities/');
     expect(tpl).toContain('{{wikiFolder}}/entities/');
+  });
+});
+
+// #188: merge.ts must use {{section_*}} placeholders, not hardcoded English headers
+describe('Prompt templates — merge.ts section headers (#188)', () => {
+  it('mergeEntityPage uses {{section_*}} placeholders for Related sections', () => {
+    const tpl = MERGE_PROMPTS.mergeEntityPage;
+    // Must use placeholders, not hardcoded English
+    expect(tpl).toContain('{{section_related_entities}}');
+    expect(tpl).toContain('{{section_related_concepts}}');
+    expect(tpl).toContain('{{section_basic_information}}');
+    expect(tpl).toContain('{{section_description}}');
+    expect(tpl).toContain('{{section_mentions_in_source}}');
+  });
+
+  it('mergeConceptPage uses {{section_*}} placeholders for Related sections', () => {
+    const tpl = MERGE_PROMPTS.mergeConceptPage;
+    expect(tpl).toContain('{{section_related_entities}}');
+    expect(tpl).toContain('{{section_related_concepts}}');
+    expect(tpl).toContain('{{section_basic_information}}');
+    expect(tpl).toContain('{{section_description}}');
+    expect(tpl).toContain('{{section_mentions_in_source}}');
   });
 });

--- a/src/wiki/page-factory.ts
+++ b/src/wiki/page-factory.ts
@@ -67,7 +67,7 @@ export class PageFactory {
     let newFm: string;
     if (fmText.includes('aliases:')) {
       // Replace existing aliases block
-      newFm = fmText.replace(/^aliases:[\s\S]*?(?=\n\S|\n*$)/m, aliasesLine);
+      newFm = fmText.replace(/^aliases:[^\n]*(?:\n[ \t]+[^\n]*)*/m, aliasesLine);
     } else {
       // Inject before closing ---
       newFm = fmText.trimEnd() + '\n' + aliasesLine;

--- a/src/wiki/prompts/merge.ts
+++ b/src/wiki/prompts/merge.ts
@@ -51,11 +51,11 @@ Rules:
   mergeEntityPage: `You are a Wiki editor performing intelligent content integration. Merge new source information into an existing page following the schema-defined structure.
 
 **Schema Rules (MUST follow this structure):**
-- ## Basic Information: Type, sources, key attributes
-- ## Description: Core definition and significance (3-6 sentences)
-- ## Related Entities: Links to related entities
-- ## Related Concepts: Links to related concepts
-- ## Mentions in Source: Chronological list of mentions with VERBATIM quotes in original language
+- ## {{section_basic_information}}: Type, sources, key attributes
+- ## {{section_description}}: Core definition and significance (3-6 sentences)
+- ## {{section_related_entities}}: Links to related entities
+- ## {{section_related_concepts}}: Links to related concepts
+- ## {{section_mentions_in_source}}: Chronological list of mentions with VERBATIM quotes in original language
 
 **Existing Page Content (the current version):**
 {{existing_body}}
@@ -73,9 +73,9 @@ Rules:
 **Integration Requirements:**
 1. STRUCTURE: Follow the schema sections exactly. If a section exists, update it; if missing, create it.
 2. DESCRIPTION: Integrate new facts naturally. Do NOT duplicate existing information.
-3. RELATED: Update "Related Entities" and "Related Concepts" sections with new relationships.
+3. RELATED: Update "{{section_related_entities}}" and "{{section_related_concepts}}" sections with new relationships.
 4. CONTRADICTIONS: If new info conflicts with existing, preserve BOTH with clear attribution.
-5. MENTIONS: Append new mentions to "Mentions in Source". Preserve VERBATIM quotes in original language. Translation optional in parentheses.
+5. MENTIONS: Append new mentions to "{{section_mentions_in_source}}". Preserve VERBATIM quotes in original language. Translation optional in parentheses.
 6. LINKS: Use [[path|display]] format. LEFT side = full path, RIGHT side = display name ONLY. NEVER duplicate folder prefixes (entities/, concepts/) in display name. Verify paths exist.
 7. STYLE: Match existing writing style.
 8. NO REDUNDANCY: Do NOT restate existing facts.
@@ -83,19 +83,19 @@ Rules:
 **Output Format:**
 Output ONLY the body content (no frontmatter):
 
-## Basic Information
+## {{section_basic_information}}
 [Type, sources, key attributes — updated]
 
-## Description
+## {{section_description}}
 [Integrated description — merge existing + new, no duplication]
 
-## Related Entities
+## {{section_related_entities}}
 [Updated entity links]
 
-## Related Concepts
+## {{section_related_concepts}}
 [Updated concept links]
 
-## Mentions in Source
+## {{section_mentions_in_source}}
 [ALL mentions — existing preserved with their source attribution blocks, new appended under a new source block:
 > **Source: [[source-name]]**
 > - "Verbatim quote in original language"]`,
@@ -103,11 +103,11 @@ Output ONLY the body content (no frontmatter):
   mergeConceptPage: `You are a Wiki editor performing intelligent content integration. Merge new source information into an existing concept page following the schema-defined structure.
 
 **Schema Rules (MUST follow this structure):**
-- ## Basic Information: Type, sources, definition
-- ## Description: Detailed explanation with examples (3-6 sentences)
-- ## Related Concepts: Connected concepts using [[concepts/...]]
-- ## Related Entities: Connected entities using [[entities/...]]
-- ## Mentions in Source: VERBATIM quotes in original language with source attribution
+- ## {{section_basic_information}}: Type, sources, definition
+- ## {{section_description}}: Detailed explanation with examples (3-6 sentences)
+- ## {{section_related_concepts}}: Connected concepts using [[concepts/...]]
+- ## {{section_related_entities}}: Connected entities using [[entities/...]]
+- ## {{section_mentions_in_source}}: VERBATIM quotes in original language with source attribution
 
 **Existing Page Content (the current version):**
 {{existing_body}}
@@ -128,7 +128,7 @@ Output ONLY the body content (no frontmatter):
 3. RELATED CONCEPTS: Update links — add new ones, preserve existing.
 4. RELATED ENTITIES: Update links — add new ones from this source.
 5. CONTRADICTIONS: If new info conflicts, preserve both with attribution.
-6. MENTIONS: Append to "Mentions in Source". Preserve VERBATIM quotes in original language.
+6. MENTIONS: Append to "{{section_mentions_in_source}}". Preserve VERBATIM quotes in original language.
 7. LINKS: Use [[path|display]] format. LEFT side = full path, RIGHT side = display name ONLY. NEVER duplicate folder prefixes (entities/, concepts/) in display name. Verify paths exist.
 8. STYLE: Match existing writing style.
 9. NO REDUNDANCY: Do NOT restate existing facts.
@@ -136,19 +136,19 @@ Output ONLY the body content (no frontmatter):
 **Output Format:**
 Output ONLY the body content (no frontmatter):
 
-## Basic Information
+## {{section_basic_information}}
 [Type, sources, definition — updated]
 
-## Description
+## {{section_description}}
 [Integrated description — merge existing + new]
 
-## Related Concepts
+## {{section_related_concepts}}
 [Updated concept links]
 
-## Related Entities
+## {{section_related_entities}}
 [Updated entity links]
 
-## Mentions in Source
+## {{section_mentions_in_source}}
 [ALL mentions — existing preserved with their source attribution blocks, new appended under a new source block:
 > **Source: [[source-name]]**
 > - "Verbatim quote in original language"]`,


### PR DESCRIPTION
Bugfixes for v1.22.0 release:
- #186: appendAliases block-replace regex stale items (regex fix + regression test)
- #188: merge.ts hardcoded English section headers ({{section_*}} placeholders + regression tests)
- Tests: 1006 passing (+3)

Closes #186, #188