### PR TITLE
feat: convert Query Wiki from Modal to Copilot-style right-docked side panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Thumbs.db
 docs/superpowers/
 
 .mimocode/
+data.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Query Wiki moved from a centered Modal to a Copilot-style right-docked side panel.** `QueryModal extends Modal` became `QueryView extends ItemView` (registered via `registerView(VIEW_TYPE_QUERY, …)`). The command `query-wiki` and a new `message-circle` ribbon icon now activate/reveal a right sidebar leaf (reusing the existing leaf if already open) instead of opening a popup. All existing behavior is preserved unchanged: three-tier retrieval, streaming + non-streaming fallback, collapsible thinking panel, save-to-wiki feedback loop, LLM save suggestion, history cap, clear, copy, and stop. The `renderThinkingBlocksUI` pure function and the post-query `SuggestSaveModal` are untouched.
+- **Query panel styling now uses native theme variables.** All hardcoded colors (`#4caf50`, `#fff3e0`, `#2196f3`, `#f44336`, `#999`, `white`) were replaced with `var(--…)` tokens so the panel adapts to light/dark themes automatically. The fixed-size `.llm-wiki-query-modal` (800×780) rule was removed in favor of a flex `.llm-wiki-query-view` root.
+
+### Tests
+- **1003 tests passing (unchanged).** obsidian test mock extended with `ItemView` / `WorkspaceLeaf` stubs so `query-engine.ts` still imports cleanly under vitest; existing `renderThinkingBlocksUI` suite stays green.
+
 ## [1.22.0] - 2026-06-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,9 @@
 
 ## Current Phase: v1.22.0 Released
 
+### In Progress (Unreleased) — Query Wiki Right-Docked Side Panel
+- 🔄 **Query Wiki: Modal → Copilot-style right side panel.** `QueryModal extends Modal` → `QueryView extends ItemView` (`VIEW_TYPE_QUERY`, registered via `registerView`). `query-wiki` command + new `message-circle` ribbon icon now activate/reveal a right sidebar leaf (reusing an existing leaf) instead of a popup. All existing behavior preserved (three-tier retrieval, streaming + fallback, thinking panel, save loop, LLM save suggestion, history cap, clear, copy, stop). `renderThinkingBlocksUI` pure fn + `SuggestSaveModal` untouched. Styles migrated to native `var(--…)` theme variables (0 hardcoded colors). Test mock extended with `ItemView`/`WorkspaceLeaf`. **1003 tests still passing.**
+
 ### Completed (v1.22.0) — Schema One-Click Apply + Dynamic Tag Sync + zh-Hant + Status Bar (2026-06-23)
 - ✅ **#97 — Schema one-click apply with IDE-style diff Modal + auto-backup.** `SchemaDiffModal` class (dual-pane IDE-style diff, Apply/Cancel/Open file buttons, Regenerate hidden for v1.22). `applySchemaSuggestion()` with auto-backup to `.llm-wiki-backups/schema/` (rotation MAX_BACKUPS=3 via `core/backup-rotation.ts`). `lineDiff()` LCS algorithm in `core/diff.ts`. Lint "Update Schema" button removed from command palette — schema updates flow through Lint Modal only.
 - ✅ **Schema dynamic tag sync.** Schema vocabulary is now the single source of truth; tag vocab injected into generation prompts. `SchemaContext` + `buildSchemaSectionTemplate` + tag vocabulary injection.
@@ -101,7 +104,7 @@ src/
 ├── llm-client-wrapper.ts           # Advanced settings injection wrapper
 ├── wiki/                           # Wiki engine
 │   ├── wiki-engine.ts              # Orchestrator
-│   ├── query-engine.ts             # Conversational query (streaming + thinking UI)
+│   ├── query-engine.ts             # Conversational query — QueryView (right-docked ItemView side panel), streaming + thinking UI
 │   ├── source-analyzer.ts          # Iterative batch extraction
 │   ├── page-factory.ts             # Entity/concept CRUD + merge
 │   ├── conversation-ingest.ts      # Chat → wiki knowledge

--- a/src/__tests__/__support__/setup.ts
+++ b/src/__tests__/__support__/setup.ts
@@ -62,6 +62,38 @@ vi.mock('obsidian', () => ({
     onOpen() {}
     onClose() {}
   },
+  // ItemView base class (simplified for testing) — used by QueryView.
+  // Without this, importing query-engine.ts (`class QueryView extends
+  // ItemView`) throws "extends undefined" at module load.
+  ItemView: class {
+    app: unknown;
+    leaf: unknown;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    contentEl: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    containerEl: any;
+    constructor(leaf: unknown) {
+      this.leaf = leaf;
+      this.contentEl = {};
+      this.containerEl = {};
+    }
+    onOpen(): Promise<void> {
+      return Promise.resolve();
+    }
+    onClose(): Promise<void> {
+      return Promise.resolve();
+    }
+    getViewType(): string {
+      return '';
+    }
+    getDisplayText(): string {
+      return '';
+    }
+    getIcon(): string {
+      return '';
+    }
+  },
+  WorkspaceLeaf: class {},
   // Platform detection
   Platform: {
     isMacOS: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,7 +85,7 @@ import { normalizeVocabularyCsv } from './core/tag-vocab';
 import { buildIngestStatusBarText, BatchProgress } from './core/status-bar';
 import { LLMWikiSettingTab } from './ui/settings';
 import { WikiEngine } from './wiki/wiki-engine';
-import { QueryModal } from './wiki/query-engine';
+import { QueryView, VIEW_TYPE_QUERY } from './wiki/query-engine';
 import { FileSuggestModal, FolderSuggestModal, IngestReportModal, ConfirmModal } from './ui/modals';
 import { HistoryModal } from './ui/history-modal';
 import { SchemaDiffModal } from './ui/schema-diff-modal';
@@ -159,6 +159,11 @@ export default class LLMWikiPlugin extends Plugin {
     if (this.settings.startupCheck) {
       void this.autoMaintainManager.runStartupCheck();
     }
+
+    this.registerView(
+      VIEW_TYPE_QUERY,
+      (leaf) => new QueryView(leaf, this)
+    );
 
     const t = TEXTS[this.settings.language];
     this.addCommand({
@@ -243,6 +248,10 @@ export default class LLMWikiPlugin extends Plugin {
 
     this.addRibbonIcon('sticker', t.cmdIngestActiveFile, () => {
       this.ingestActiveFile();
+    });
+
+    this.addRibbonIcon('message-circle', t.cmdQueryWiki, () => {
+      this.queryWiki();
     });
 
     this.ingestStatusBar = this.addStatusBarItem();
@@ -643,7 +652,22 @@ export default class LLMWikiPlugin extends Plugin {
       return;
     }
 
-    new QueryModal(this.app, this).open();
+    void this.activateQueryView();
+  }
+
+  private async activateQueryView(): Promise<void> {
+    const { workspace } = this.app;
+
+    const existing = workspace.getLeavesOfType(VIEW_TYPE_QUERY);
+    if (existing.length > 0) {
+      await workspace.revealLeaf(existing[0]);
+      return;
+    }
+
+    const leaf = workspace.getRightLeaf(false);
+    if (!leaf) return;
+    await leaf.setViewState({ type: VIEW_TYPE_QUERY, active: true });
+    await workspace.revealLeaf(leaf);
   }
 
   // ==================== Lint ====================

--- a/src/wiki/query-engine.ts
+++ b/src/wiki/query-engine.ts
@@ -1,6 +1,6 @@
 // Query Engine - Conversational Wiki Query Modal
 
-import { App, Modal, Notice, MarkdownRenderer, Component, Platform } from 'obsidian';
+import { App, Modal, ItemView, WorkspaceLeaf, Notice, MarkdownRenderer, Component, Platform } from 'obsidian';
 import LLMWikiPlugin from '../main';
 import { TEXTS } from '../texts';
 import { WIKI_LANGUAGES } from '../types';
@@ -147,9 +147,11 @@ class SuggestSaveModal extends Modal {
   }
 }
 
-// ---- Query Modal ----
+// ---- Query View (right-docked side panel) ----
 
-export class QueryModal extends Modal {
+export const VIEW_TYPE_QUERY = 'llm-wiki-query-view';
+
+export class QueryView extends ItemView {
   plugin: LLMWikiPlugin;
   history: {
     messages: Array<{
@@ -169,8 +171,8 @@ export class QueryModal extends Modal {
   private pendingInput: string;
   private activeRenderComponent: Component | null;
 
-  constructor(app: App, plugin: LLMWikiPlugin) {
-    super(app);
+  constructor(leaf: WorkspaceLeaf, plugin: LLMWikiPlugin) {
+    super(leaf);
     this.plugin = plugin;
     this.history = {
       messages: plugin.settings.queryHistory || []
@@ -187,12 +189,24 @@ export class QueryModal extends Modal {
     this.pendingInput = '';
   }
 
-  onOpen() {
+  getViewType(): string {
+    return VIEW_TYPE_QUERY;
+  }
+
+  getDisplayText(): string {
+    return TEXTS[this.plugin.settings.language].queryModalTitle;
+  }
+
+  getIcon(): string {
+    return 'message-circle';
+  }
+
+  async onOpen() {
     const { contentEl } = this;
     contentEl.empty();
     const texts = TEXTS[this.plugin.settings.language];
 
-    this.modalEl.addClass('llm-wiki-query-modal');
+    contentEl.addClass('llm-wiki-query-view');
     contentEl.addClass('llm-wiki-query-content');
 
     const container = contentEl.createDiv({
@@ -289,7 +303,7 @@ export class QueryModal extends Modal {
     );
   }
 
-  onClose() {
+  async onClose() {
     const { contentEl } = this;
 
     if (this.activeRenderComponent) {

--- a/styles.css
+++ b/styles.css
@@ -63,16 +63,13 @@
   margin: 10px 0;
 }
 
-/* Query Modal */
-.llm-wiki-query-modal {
-  width: 800px;
-  height: 780px;
+/* Query View (right-docked side panel) */
+.llm-wiki-query-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   padding: 0;
   overflow: hidden;
-}
-
-.llm-wiki-query-modal .modal-header {
-  display: none;
 }
 
 .llm-wiki-query-content {
@@ -87,19 +84,21 @@
 }
 
 .llm-wiki-query-header {
-  background: #4caf50;
-  color: white;
-  padding: 12px;
-  font-weight: bold;
-  font-size: 16px;
+  background: var(--background-secondary);
+  color: var(--text-normal);
+  padding: 10px 12px;
+  font-weight: 600;
+  font-size: 15px;
+  border-bottom: 1px solid var(--background-modifier-border);
   flex-shrink: 0;
 }
 
 .llm-wiki-query-hint {
-  background: #fff3e0;
-  padding: 8px 16px;
-  font-size: 13px;
-  color: #666666;
+  background: var(--background-secondary);
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--background-modifier-border);
   flex-shrink: 0;
 }
 
@@ -107,14 +106,14 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 16px;
+  padding: 12px;
   background: var(--background-primary);
 }
 
 .llm-wiki-query-input-container {
-  border-top: 2px solid #dddddd;
-  padding: 16px;
-  background: white;
+  border-top: 1px solid var(--background-modifier-border);
+  padding: 12px;
+  background: var(--background-primary);
   flex-shrink: 0;
 }
 
@@ -126,8 +125,8 @@
 
 .llm-wiki-query-send-btn {
   flex: 2;
-  background: #2196f3;
-  color: white;
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
   padding: 8px;
   cursor: pointer;
   border: none;
@@ -136,8 +135,8 @@
 
 .llm-wiki-query-stop-btn {
   flex: 2;
-  background: #f44336;
-  color: white;
+  background: var(--text-error);
+  color: var(--text-on-accent);
   padding: 8px;
   cursor: pointer;
   border: none;
@@ -146,8 +145,8 @@
 
 .llm-wiki-query-save-btn {
   flex: 1;
-  background: var(--interactive-accent);
-  color: white;
+  background: var(--interactive-normal);
+  color: var(--text-normal);
   padding: 8px;
   cursor: pointer;
   border: none;
@@ -155,8 +154,8 @@
 }
 
 .llm-wiki-query-clear-btn {
-  background: #999999;
-  color: white;
+  background: var(--interactive-normal);
+  color: var(--text-muted);
   padding: 8px;
   cursor: pointer;
   border: none;
@@ -166,7 +165,7 @@
 .llm-wiki-query-count {
   margin-top: 8px;
   font-size: 11px;
-  color: #999999;
+  color: var(--text-faint);
 }
 
 .llm-wiki-query-message-wrapper {
@@ -361,7 +360,7 @@
 }
 
 .llm-wiki-query-response-live .llm-wiki-query-message-label {
-  color: #4caf50;
+  color: var(--interactive-accent);
 }
 
 .llm-wiki-query-status {


### PR DESCRIPTION
## Summary
Converts Query Wiki from a centered popup (Modal) into a Copilot-style right-docked chat panel (Obsidian `ItemView`), so the conversation can stay open alongside notes instead of interrupting with a popup every time. **All functionality and interactions are strictly preserved** — this change only alters the host surface and visual styling.
- `QueryModal extends Modal` → `QueryView extends ItemView` (new `VIEW_TYPE_QUERY`, registered via `registerView`). The `query-wiki` command and a new `message-circle` ribbon icon activate/reveal a right sidebar leaf, reusing an existing leaf if one is already open.
- Styling moves from the fixed-size `.llm-wiki-query-modal` (800×780) to a flex `.llm-wiki-query-view` layout; all hardcoded colors (`#4caf50` / `#fff3e0` / `#2196f3` / `#f44336` / `#999` / `white`) are replaced with native `var(--…)` theme variables for automatic light/dark adaptation.
## Behavior Preserved
Three-tier retrieval, streaming generation + non-streaming fallback, collapsible thinking panel, save-to-wiki feedback loop, LLM save suggestion, history-round cap, clear, copy, and stop. The `renderThinkingBlocksUI` pure function and the post-query `SuggestSaveModal` are untouched.


## demo
<img width="511" height="1015" alt="image" src="https://github.com/user-attachments/assets/9c31e17d-ae8b-4ba7-a402-ed05366e5bad" />
