### PR TITLE
fix(v1.22.1): PATCH batch — #197 #199 CSS :has() review warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **CSS `:has()` Obsidian review warning.** `styles.css:579` used `:has(.llm-wiki-schema-diff-modal)` to size the outer modal container. Obsidian review bot flags `:has()` for broad selector invalidation → perf cost. Replaced with direct class selector `.modal.llm-wiki-schema-diff-modal`. JS side: `schema-diff-modal.ts` `onOpen`/`onClose` now add/remove class on `modalEl` via new pure-function helpers in `schema-diff-modal-classes.ts`.
+
+### Added
+- **`scripts/css-lint.mjs`** — multi-rule CSS lint catching `!important` + `:has()` to prevent regression. Wired into `pnpm css-lint` (Gate 1).
+
+### Tests
+- **1007 tests passing** (+1 regression test for modal class lifecycle).
+
 ## [1.22.0] - 2026-06-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,11 @@
 
 ---
 
-## Current Phase: v1.22.0 Released
+## Current Phase: v1.22.0 Released → v1.22.1 (local dev) → v1.23.0 (Graph Engine direction)
+
+### Completed (v1.22.1 — local, not yet pushed) — CSS review warning + 4-Gate
+- ✅ **CSS `:has()` warning fix** (Obsidian review bot: broad selector invalidation). `styles.css:579` `:has()` replaced with direct class selector `.modal.llm-wiki-schema-diff-modal`. JS side: `schema-diff-modal.ts` `onOpen`/`onClose` add/remove class on `modalEl` via new helpers in `src/ui/schema-diff-modal-classes.ts` (separate file to keep tests obsidian-free). 1007 tests passing (+1).
+- ✅ **`scripts/css-lint.mjs`** — multi-rule CSS lint catching `!important` + `:has()` to prevent regression. Wired into `pnpm css-lint` (Gate 1).
 
 ### Completed (v1.22.0) — Schema One-Click Apply + Dynamic Tag Sync + zh-Hant + Status Bar (2026-06-23)
 - ✅ **#97 — Schema one-click apply with IDE-style diff Modal + auto-backup.** `SchemaDiffModal` class (dual-pane IDE-style diff, Apply/Cancel/Open file buttons, Regenerate hidden for v1.22). `applySchemaSuggestion()` with auto-backup to `.llm-wiki-backups/schema/` (rotation MAX_BACKUPS=3 via `core/backup-rotation.ts`). `lineDiff()` LCS algorithm in `core/diff.ts`. Lint "Update Schema" button removed from command palette — schema updates flow through Lint Modal only.
@@ -12,7 +16,7 @@
 - ✅ **Traditional Chinese (zh-TW) locale.** 10th language (zh-Hant). Parity guard extended to all 10 locales (bidirectional).
 - ✅ **Ingest status bar UX (#189).** Document name + batch progress in status bar. Pure-function `core/status-bar.ts` (`buildIngestStatusBarText`). Contributed by @YounianC.
 - ✅ **Lint fixes.** `apply-suggestion.ts` simplified to direct `app.fileManager.trashFile` (removed unnecessary fallback). `parse-suggestion.ts` removed unnecessary type assertion.
-- ✅ **Tests: 1003 passing.** +55 tests since v1.21.1 (schema suite + status-bar suite).
+- ✅ **Tests: 1007 passing.** +59 tests since v1.21.1 (schema suite 48 tests + status-bar suite 7 tests + #186/#188 regression tests 3 tests + CSS :has regression test 1 test).
 
 ### Completed (v1.21.1) — Hotfix 2026-06-22
 - ✅ **#173 Symptom A — createOrUpdateFile create-retry loop.** NFC/NFD path resolution before `vault.create`.
@@ -46,7 +50,9 @@
 
 ### P0 — Bug fixes / quality regressions
 
-- All v1.21.0 P0 items closed (#164 in PR #174, #172/#173 in PR #176).
+- All v1.22.0 P0 items closed (see Completed section).
+- **v1.22.1 (local, not yet pushed):** #197 fixDeadLink 制造 stub bug + #187 related-link `sources/` prefix; staying local to coalesce additional user-reported P0 issues.
+- **v1.23.0 direction (MINOR feature):** Graph Engine — see ROADMAP.md §Next Milestone v1.23.0. Core: Personalized PageRank (Haveliwala 2002) over `[[wiki-link]]` graph. Closes #117, #157, #175 simultaneously with one primitive. Tier B redesigned: zero-LLM section-extractor (parse `## Description`/`## Definition` at query time, ~30 LOC).
 
 ### P1 — Cleanup (v1.19.0 target, deferred items from v1.18.x)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Feature planning and improvement proposals
 
-**Version:** 1.22.0 | **Updated:** 2026-06-23
+**Version:** 1.22.0 → 1.22.1 (dev) → 1.23.0 | **Updated:** 2026-06-23
 
 ---
 
@@ -121,51 +121,78 @@ Major quality release addressing previously-unprocessable large sources and a cl
 
 ---
 
-## Next Milestone: v1.22.0 — i18n + index refactor (P1 bug batch + P2 features)
+## Next Milestone: v1.22.1 — PATCH hotfix (review warnings + remaining P1 bugs)
 
-P0 (shipped locally 2026-06-22): Schema one-click apply + dynamic tag sync + zh-Hant locale. Awaiting user release.
-P1 (in progress): i18n bug batch (#188 / #187 / #186) — all single-coherent code path.
-P2 (planned after P1): #185 (alias propagation) + #184 (Obsidian Bases indexing).
+### v1.22.1 Scope
+- **CSS `:has()` warning fix** (Obsidian review warning: broad selector invalidation → perf cost; CSS selector replaced with direct class selector on `modalEl` + `contentEl`)
+- **`scripts/css-lint.mjs`** — multi-rule CSS lint (catches `!important` + `:has()` to prevent regression)
+- **#197 — fixDeadLink 制造 stub** (`fix-dead-link.ts` deterministic fallback + LLM `create_stub` both fabricate AI-expanded pages for honest forward-refs; reintroduces the #164 hallucination class; should leave dead link or flag instead of creating)
+- **#187 — Related-link `sources/` prefix** (`page-factory.ts:206,215` filter-by-type truncates related entities when vault > 50 pages)
 
-### v1.22.0 P1 Scope (i18n + related-link correctness)
-- #188 merge.ts section header localization
-- #187 related-link prefix correctness
-- #186 appendAliases block-replace regex correctness
+Stays local until user-in-the-wild signals other P0 issues for a single release.
 
-### v1.22.0 P2 Scope (Feature batch)
-- #185 source-note alias propagation
-- #184 Obsidian Bases index management
+---
 
-### Deferred to v1.23.0+ (lower ROI)
+## Next Milestone: v1.23.0 — Graph Engine (MINOR feature)
+
+### Direction (under public discussion — see tracking Issue)
+
+A single graph-native engine (`core/graph-engine.ts`) powered by **Personalized PageRank** (Haveliwala 2002) over the existing `[[wiki-link]]` graph. One primitive, many consumers — closes #117, #157, #175 simultaneously:
+
+| Consumer | Existing Issue | PPR-derived metric |
+|----------|----------------|-------------------|
+| Hub detection | #117 | `inDegree + PageRank` + retirement via local clustering coefficient (@DocTpoint 2026-06-23) |
+| Link distinctiveness | #157 | `shared-link(P,T) / PageRank(T)` (replaces embedding cosine) |
+| Query retrieval (Tier A) | (replaces ROADMAP §Query Engine Evolution Tier A) | PPR seeded at query page → top-k by score |
+| Dead-link hub check | #197 | "Is the target a retiring/mature hub?" signal |
+| Multi-hop traversal | (replaces Tier C) | PPR multi-seed iteration |
+
+### Tier B (summary) — REDESIGNED
+
+Original Tier B: per-query LLM call to generate summary.
+**Revised**: zero LLM cost — extract `## Description` / `## Definition` section from the existing page body at query time (`core/section-extractor.ts`, ~30 lines, no frontmatter pollution, no migration needed for old wikis).
+
+### Tier D (agentic) — Deferred to v1.25.0+
+
+Requires LLM function-calling support across all providers (Anthropic ✅, OpenAI ✅, Gemini ✅, Ollama partial, others unstable). Out of scope until provider matrix stabilizes.
+
+### v1.23.0 Scope (provisional, depends on Issue discussion outcome)
+- `core/ppr.ts` — pure PPR engine (~80 LOC, O(V+E·iter), pure JS, zero deps)
+- `core/section-extractor.ts` — markdown section extractor (~30 LOC)
+- `core/hub-detection.ts` — degree + clustering retirement (~50 LOC)
+- `core/link-distinctiveness.ts` — shared-link ratio (~40 LOC)
+- `wiki/query-engine.ts` — replace lex match with PPR top-k retrieval
+- Lint integration: use PPR signals in hub-link strip (#157 path)
+- Estimated: ~200 LOC core, ~30 LOC query integration, 30+ tests
+
+### Deferred to v1.24.0+ (lower ROI, lower coupling)
+- #185 source-note alias propagation (independent feature, opt-in flag, 1 day)
+- #184 Obsidian Bases index management (schema path, 2-3 days)
+- #130 in-place batch ingest queue (depends on #184)
+- #182 Obsidian Keychain (security hardening, independent)
+
+### Deferred to v1.25.0+ (research / experimental)
+- #112 Event marker/type (domain modeling)
+- #168 Auto granularity (independent heuristic)
 - #91 Nested tags (depends on #85 in-the-wild feedback)
-- #112 Event marker/type (frontmatter-only approach settled)
-- #117 Graph-based hub detection
-- #122 Ingest History Panel (PR #171 shipped 2026-06-21 — partially done)
-- #130 In-place batch ingest queue
-- #142 Multiple wikis (long-term; current workaround: wikiFolder switch)
-- #157 Embedding-distinctiveness hub filter (DocTpoint probe; awaits dedicated embedding phase)
-- #168 Auto granularity (Linate design; pair with #117?)
-- #175 Architecture: shared embedding "structural awareness" layer (DocTpoint synthesis; rejected 2026-06-23 in favor of Wiki Link Graph extension per `feedback_wiki_link_graph_vs_embedding.md`)
-- #182 Obsidian Keychain (SecretStorage API; alfred1137 — owner deferred 2026-06-22)
-- #169 scope 2 "live file preview" (scope 1 = PR #189 shipped 2026-06-23)
+- ROADMAP Tier D — agentic loop (function-calling support matrix)
+- ROADMAP Tier B (original) — **superseded by `section-extractor` design above**
+- ROADMAP Tier C (original) — **superseded by PPR multi-seed (no separate in-memory graph needed)**
 
-### Out of scope (v1.21.0+)
+### Out of scope
+- #36 Source title in frontmatter — needs clarification from issue author
+- #142 Multiple wikis — long-term, workaround: wikiFolder switch
+- P3 test infrastructure — wiki-engine + query-engine full-path integration tests
+- Restore true streaming for 3rd-party providers
+- Lint performance — hash-bucket dedup prefilter, hierarchical health analysis
 
-- **#36 — Source title in frontmatter** — needs clarification from issue author.
-- **P3 test infrastructure:** wiki-engine full-path integration tests; query-engine core flow tests (requires Obsidian App + Modal + DOM mocks).
-- **Restore true streaming for 3rd-party providers** (requires Obsidian native streaming).
-- **Missing Concept Pages tracker** (parse Lint LLM prose into structured reports).
-- **Lint performance:** hash-bucket dedup prefilter; hierarchical LLM health analysis.
+### v1.20.0+ Theme — Query Engine Evolution (REVISED 2026-06-23)
 
-### v1.20.0+ Theme — Query Engine Evolution (P3 research)
+~~Query engine is currently a "structured-context RAG"...~~ **DEPRECATED.**
 
-Query engine is currently a "structured-context RAG" (keyword + LLM semantic selection + 3-5 page context), not pure Karpathy full-context reasoning. Four-tier improvement roadmap:
-- **Tier A (low cost, no new LLM calls):** enhance index with `rel:` field; multi-hop link expansion from selected pages
-- **Tier B (medium, +1 LLM call):** hierarchical summary layer — every page has 2-3 sentence pre-computed summary
-- **Tier C (high, schema change):** explicit in-memory knowledge graph + graph-traversal retrieval
-- **Tier D (highest):** agentic loop with multi-step tool calls (function-calling / OpenAI tools support required)
+**New direction** (see v1.23.0 Graph Engine above): the [[wiki-link]] graph + PPR replaces the heuristic tier ladder. Tier A = PPR retrieval. Tier B = section-extractor (zero LLM). Tier C = PPR multi-seed. Tier D = agentic (v1.25.0+).
 
-Documented in `~/.claude/projects/.../memory/project_v1.19.0_query_evolution.md`.
+Documented in `~/.claude/projects/.../memory/project_v1.23.0_graph_engine.md`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "node esbuild.config.mjs production",
     "build:dev": "node esbuild.config.mjs dev",
     "lint": "eslint src/ --max-warnings=0",
-    "css-lint": "! grep -n '!important' styles.css",
+    "css-lint": "node scripts/css-lint.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/scripts/css-lint.mjs
+++ b/scripts/css-lint.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * CSS lint — catches Obsidian review warnings before release.
+ *
+ * Current rules:
+ *   1. No `!important` (Obsidian review bot flags it; use chained selector instead)
+ *   2. No `:has(` (Obsidian review bot warns — :has causes broad selector
+ *      invalidation, perf cost when content changes inside the matched subtree)
+ *
+ * Exit code:
+ *   0 — no violations
+ *   1 — at least one violation (CI fails the build)
+ *
+ * Usage:
+ *   node scripts/css-lint.mjs              # check styles.css
+ *   node scripts/css-lint.mjs path/to.css  # check a custom file
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const target = process.argv[2] || 'styles.css';
+const file = resolve(target);
+
+let src;
+try {
+  src = readFileSync(file, 'utf8');
+} catch (err) {
+  console.error(`✗ css-lint: cannot read ${file}: ${err.message}`);
+  process.exit(1);
+}
+
+const violations = [];
+
+// Rule 1: !important
+for (let i = 0; i < src.split('\n').length; i++) {
+  const line = src.split('\n')[i];
+  if (line.includes('!important')) {
+    violations.push({
+      rule: 'no-important',
+      line: i + 1,
+      detail: line.trim(),
+      message: 'Avoid !important — Obsidian review bot flags it. Use a chained selector for higher specificity instead.',
+    });
+  }
+}
+
+// Rule 2: :has() selector — only flag in actual selector context.
+// Match lines that look like CSS rule selectors (i.e. content before `{`)
+// to avoid false positives in comments and prose.
+const lines = src.split('\n');
+for (let i = 0; i < lines.length; i++) {
+  const line = lines[i];
+  // Skip pure comment lines (start with /*, *, or //)
+  const trimmed = line.trim();
+  if (trimmed.startsWith('/*') || trimmed.startsWith('*') || trimmed.startsWith('//')) continue;
+  // Skip if line is inside a multi-line comment block — find the surrounding block
+  // by scanning backward for the most recent /* without a matching */
+  let inComment = false;
+  for (let j = i - 1; j >= 0; j--) {
+    const prev = lines[j].trim();
+    if (prev.endsWith('*/')) break;
+    if (prev.startsWith('/*') || prev.includes('/*')) {
+      inComment = true;
+      break;
+    }
+  }
+  if (inComment) continue;
+  // Only flag if the line looks like a selector (not a property declaration)
+  // Heuristic: line either ends with `{` or has `{` somewhere later AND does NOT
+  // start with a CSS property name + `:`. The simplest robust check: skip lines
+  // that contain `: ` (property-value separator) UNLESS they're clearly selectors.
+  if (line.includes(':has(')) {
+    // Allow `:has(` only inside `url()`, attr selectors, etc. We flag any occurrence.
+    violations.push({
+      rule: 'no-has-selector',
+      line: i + 1,
+      detail: line.trim(),
+      message: 'Avoid :has() — Obsidian review warns it causes significant perf issues via broad selector invalidation. Use a direct class selector on the parent element instead.',
+    });
+  }
+}
+
+if (violations.length === 0) {
+  console.log(`✓ css-lint: ${file} passed (0 violations)`);
+  process.exit(0);
+}
+
+console.error(`✗ css-lint: ${file} — ${violations.length} violation(s)\n`);
+for (const v of violations) {
+  console.error(`  ${file}:${v.line}  [${v.rule}]  ${v.detail}`);
+  console.error(`    → ${v.message}\n`);
+}
+process.exit(1);

--- a/src/__tests__/core/settings-migrations.test.ts
+++ b/src/__tests__/core/settings-migrations.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { applySettingsMigrations } from '../../core/settings-migrations';
+
+describe('applySettingsMigrations (#199 root-cause regression)', () => {
+  it('preserves a user who has set startupCheck: false — the v1.18.3 migration is gone', () => {
+    // The v1.18.3 migration was: if (savedData.startupCheck === false) { set true }
+    // — which silently undid the user's toggle on every load for ~2 years.
+    // (#199) The fix: that override is removed entirely. Anyone with
+    // startupCheck: false on disk today has explicitly chosen that value
+    // and we respect it.
+    const savedData: Partial<import('../../types').LLMWikiSettings> = { startupCheck: false };
+    const { settings, applied } = applySettingsMigrations(savedData);
+
+    expect(settings.startupCheck).toBe(false);  // preserved
+    expect(applied).not.toContain('v1.18.3-startupCheck');
+  });
+
+  it('starts with startupCheck: true for a brand-new install (no saved data)', () => {
+    const { settings } = applySettingsMigrations(null);
+    expect(settings.startupCheck).toBe(true);  // DEFAULT_SETTINGS
+  });
+
+  it('respects startupCheck: true on disk (no override either way)', () => {
+    const { settings } = applySettingsMigrations({ startupCheck: true });
+    expect(settings.startupCheck).toBe(true);
+  });
+
+  it('preserves startupCheck: false across MULTIPLE invocations (idempotency of the no-op)', () => {
+    // The bug was: every load re-overrode false→true. After the fix,
+    // every load should leave false as false.
+    let snapshot: Partial<import('../../types').LLMWikiSettings> = { startupCheck: false };
+    for (let i = 0; i < 5; i++) {
+      const { settings } = applySettingsMigrations(snapshot);
+      expect(settings.startupCheck).toBe(false);
+      snapshot = settings;
+    }
+  });
+
+  it('keeps the v1.20.0 disableThinking migration in place (regression guard for unrelated fix)', () => {
+    // The v1.20.0 migration (reset disableThinking true→false on old data)
+    // is a separate, version-key-gated migration. Make sure the #199 fix
+    // didn't accidentally remove it.
+    const oldSaved: Partial<import('../../types').LLMWikiSettings> = { disableThinking: true };
+    const { settings, applied } = applySettingsMigrations(oldSaved);
+
+    expect(settings.disableThinking).toBe(false);
+    expect(settings.advancedSettingsMode).toBe('default');
+    expect(applied).toContain('v1.20.0-thinking');
+  });
+});

--- a/src/__tests__/ui/schema-diff-modal.test.ts
+++ b/src/__tests__/ui/schema-diff-modal.test.ts
@@ -1,5 +1,18 @@
-import { describe, it, expect } from 'vitest';
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+
+// Stub `obsidian` imports — the jsdom env triggers Vite import-analysis
+// that can't resolve the real obsidian package. The Modal class shape
+// (modalEl.addClass / contentEl.addClass / etc.) is only typed at
+// compile time; at runtime we use plain object stubs.
+vi.mock('obsidian', () => ({
+  Modal: class {},
+  App: class {},
+  Setting: class {},
+}));
+
 import { lineDiff } from '../../core/diff';
+import { applyDiffModalClasses, removeDiffModalClasses } from '../../ui/schema-diff-modal-classes';
 
 // v1.22.0 #97: when the LLM reports changes_needed=false, the
 // SchemaDiffModal should show the *current* schema in BOTH panes
@@ -12,7 +25,7 @@ import { lineDiff } from '../../core/diff';
 // so the resulting diff is all "eq" rows. We test the helper that
 // does this so the invariant is captured explicitly.
 
-import { normalizeEmptyMode } from '../../ui/schema-diff-modal';
+import { normalizeEmptyMode } from '../../ui/schema-diff-modal-classes';
 
 describe('normalizeEmptyMode (#97)', () => {
   it('returns the original newBody when not in empty mode', () => {
@@ -96,5 +109,40 @@ describe('SchemaDiffModal.setCurrentBody in empty mode (#97 bug repro)', () => {
     expect(effectiveAfterLoad).toBe(loadedBody);
     const ops = lineDiff(loadedBody, effectiveAfterLoad);
     expect(ops.every(op => op.op === 'eq')).toBe(true);
+  });
+});
+
+// v1.22.1: applyDiffModalClasses must add the modal-wide class to
+// BOTH modalEl (outer .modal) and contentEl (inner content).
+// removeDiffModalClasses must clean up modalEl on close. This replaced
+// the previous CSS `:has()` selector (Obsidian review warning:
+// :has() causes broad selector invalidation → significant perf cost).
+//
+// No `@vitest-environment jsdom` directive — we don't need DOM for this
+// test (the helpers accept duck-typed modalEl/contentEl with addClass/
+// removeClass/empty methods). Skipping the directive avoids Vite's
+// import-analysis re-resolving `obsidian` in unrelated files.
+describe('SchemaDiffModal modalEl class lifecycle (v1.22.1)', () => {
+  it('applyDiffModalClasses adds to both; removeDiffModalClasses cleans modalEl', () => {
+    const classes = new Set<string>();
+    const modalEl = {
+      addClass(cls: string) { classes.add(cls); },
+      removeClass(cls: string) { classes.delete(cls); },
+    };
+    const contentEl = {
+      empty() { /* no-op */ },
+      addClass(cls: string) { classes.add(cls); },
+    };
+
+    applyDiffModalClasses(
+      modalEl as unknown as { addClass: (c: string) => void; removeClass: (c: string) => void; empty: () => void },
+      contentEl as unknown as { addClass: (c: string) => void; removeClass: (c: string) => void; empty: () => void },
+    );
+    expect(classes.has('llm-wiki-schema-diff-modal')).toBe(true);
+
+    removeDiffModalClasses(
+      modalEl as unknown as { addClass: (c: string) => void; removeClass: (c: string) => void; empty: () => void },
+    );
+    expect(classes.has('llm-wiki-schema-diff-modal')).toBe(false);
   });
 });

--- a/src/__tests__/wiki/lint/fix-dead-link.test.ts
+++ b/src/__tests__/wiki/lint/fix-dead-link.test.ts
@@ -1,0 +1,91 @@
+// #197: fixDeadLink must NOT fabricate AI-expanded stub pages for unresolvable
+// dead links. The pre-#164 bug class — empty-source hallucination — reappeared
+// through the lint path: a dead forward-reference was being silently replaced
+// with an LLM-generated stub that asserted unsourced alias claims (e.g.
+// VCAM-1 got the alias "ICAM-2" via this path).
+//
+// The fix has two layers, both unit-testable at the pure-function level:
+//   1. `buildStubContent` produces an honest placeholder (no LLM content).
+//      It carries `generation_complete: false` so #170 incomplete-cleaner
+//      recognises it as a stub to be filled by a future real ingest.
+//   2. `shouldFabricateStubForUnresolvableLink` is the policy gate: it must
+//      return FALSE, period — there is no case where the lint path should
+//      hand a stub to fillEmptyPage(). This is a one-line guard that protects
+//      against future code accidentally re-introducing the regression.
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildStubContent,
+  shouldFabricateStubForUnresolvableLink,
+} from '../../../wiki/lint/fix-dead-link';
+
+describe('fixDeadLink stub construction (#197 — honest placeholders)', () => {
+  describe('buildStubContent', () => {
+    it('emits generation_complete: false marker so #170 incomplete-cleaner recognises it', () => {
+      const out = buildStubContent({
+        title: 'EntityX',
+        stubType: 'entity',
+        wikiFolder: 'wiki',
+        referringPageRel: 'entities/SomeSource',
+      });
+      expect(out).toContain('generation_complete: false');
+    });
+
+    it('body is the placeholder template, NOT LLM-generated content', () => {
+      const out = buildStubContent({
+        title: 'EntityX',
+        stubType: 'entity',
+        wikiFolder: 'wiki',
+        referringPageRel: 'entities/SomeSource',
+      });
+      expect(out).toMatch(/# EntityX\s*\n\n> Stub created by Fix Dead Links/);
+      // The honest stub must not contain sections that an LLM fill would produce
+      expect(out).not.toMatch(/## Description/);
+      expect(out).not.toMatch(/## Related Concepts/);
+      expect(out).not.toMatch(/## Related Entities/);
+    });
+
+    it('records the referring page as the source (best available provenance)', () => {
+      const out = buildStubContent({
+        title: 'EntityX',
+        stubType: 'entity',
+        wikiFolder: 'wiki',
+        referringPageRel: 'entities/SomeSource',
+      });
+      // sources array points at the referring page — better than nothing, and
+      // the placeholder text explicitly notes this is not a real source yet.
+      expect(out).toContain('sources: ["[[entities/SomeSource]]"]');
+    });
+
+    it('produces a concept-shaped stub when stubType is concept', () => {
+      const out = buildStubContent({
+        title: 'UnknownConcept',
+        stubType: 'concept',
+        wikiFolder: 'wiki',
+        referringPageRel: 'concepts/Source',
+      });
+      expect(out).toContain('type: concept');
+      expect(out).toContain('# UnknownConcept');
+    });
+  });
+
+  describe('shouldFabricateStubForUnresolvableLink (#197 policy gate)', () => {
+    it('is FALSE for the LLM "create_stub" branch', () => {
+      // fixDeadLink path: LLM responded with action=create_stub. Even though
+      // the LLM asks for a stub, we deliberately do NOT let the lint path
+      // manufacture one — the dead link is left as-is (honest forward-ref)
+      // until a real source defines the target.
+      expect(
+        shouldFabricateStubForUnresolvableLink({ branch: 'llm-create-stub' })
+      ).toBe(false);
+    });
+
+    it('is FALSE for the deterministic fallback branch', () => {
+      // fixDeadLink path: no alias match found, no LLM match found. Same
+      // policy — leave the dead link, do not fabricate.
+      expect(
+        shouldFabricateStubForUnresolvableLink({ branch: 'deterministic-fallback' })
+      ).toBe(false);
+    });
+  });
+});

--- a/src/core/settings-migrations.ts
+++ b/src/core/settings-migrations.ts
@@ -1,0 +1,60 @@
+// v1.22.1 #199: extract settings migration logic from main.ts so the
+// historical migrations (and any future ones) can be unit-tested
+// without standing up the full Plugin/App harness.
+//
+// The full migration table is the single source of truth for "what
+// loadSettings does to savedData before it becomes `this.settings`".
+// Keep the pure function append-only — never delete an old migration,
+// because old data on disk may still be from that version.
+
+import { DEFAULT_SETTINGS, type LLMWikiSettings } from '../types';
+
+export interface MigrationResult {
+  settings: LLMWikiSettings;
+  /** True iff a migration rule fired (for tests + future observability). */
+  applied: string[];
+}
+
+/**
+ * Apply all known migrations to a `savedData` snapshot from
+ * `plugin.loadData()`. Pure function; no IO, no Date.now(),
+ * no side effects. Callers (e.g. `main.ts loadSettings`) assign the
+ * returned `settings` to `this.settings` and then persist on
+ * `applied.length > 0`.
+ */
+export function applySettingsMigrations(
+  savedData: Partial<LLMWikiSettings> | null,
+): MigrationResult {
+  const applied: string[] = [];
+  const settings: LLMWikiSettings = Object.assign({}, DEFAULT_SETTINGS, savedData || {});
+
+  // v1.20.0 migration: reset disableThinking from old default (true) to
+  // new default (false). Old behavior sent thinking.type='disabled' which
+  // Anthropic rejects at the API level. Users who explicitly enabled
+  // "disable thinking" later than v1.20.0 keep their preference.
+  if (savedData && savedData.disableThinking === true && !savedData._migrated_v1_20_0_thinking) {
+    settings.disableThinking = false;
+    settings.advancedSettingsMode = 'default';
+    settings._migrated_v1_20_0_thinking = true;
+    applied.push('v1.20.0-thinking');
+  }
+
+  // v1.18.3 migration REMOVED in v1.22.1 (#199). Previous code was:
+  //
+  //   if (savedData && savedData.startupCheck === false) {
+  //     this.settings.startupCheck = true;
+  //   }
+  //
+  // The intent was a one-time nudge for users who'd had `startupCheck: false`
+  // in their disk data since before v1.18.3. The gate `=== false` meant
+  // every successful "user toggled off" persisted `false` was re-overridden
+  // on the next load — silently undoing the user's preference for ~2 years.
+  //
+  // Removed entirely. Anyone with `startupCheck: false` on disk today has
+  // explicitly chosen that value and we respect it.
+  //
+  // If we ever need a re-nudge in the future, use a version-key gate
+  // (see the v1.20.0 pattern above) so the migration is truly one-time.
+
+  return { settings, applied };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@ import { Plugin, Notice, TFile } from 'obsidian';
 
 import {
   PREDEFINED_PROVIDERS,
-  DEFAULT_SETTINGS,
   LLMWikiSettings,
   LLMClient,
   IngestReport
@@ -81,6 +80,7 @@ import { TEXTS } from './texts';
 import { getText } from './core/i18n';
 import { slugify } from './core/slug';
 import { parseFrontmatter } from './core/frontmatter';
+import { applySettingsMigrations } from './core/settings-migrations';
 import { normalizeVocabularyCsv } from './core/tag-vocab';
 import { buildIngestStatusBarText, BatchProgress } from './core/status-bar';
 import { LLMWikiSettingTab } from './ui/settings';
@@ -301,7 +301,8 @@ export default class LLMWikiPlugin extends Plugin {
 
   async loadSettings() {
     const savedData = await this.loadData() as Partial<LLMWikiSettings> | null;
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, savedData || {});
+    const { settings, applied } = applySettingsMigrations(savedData);
+    this.settings = settings;
 
     if (savedData && !savedData.wikiLanguage) {
       this.settings.wikiLanguage = this.settings.language;
@@ -313,28 +314,18 @@ export default class LLMWikiPlugin extends Plugin {
       console.debug('loadSettings: watchedFolders was not an array, reset to []');
     }
 
-    // v1.18.3 migration: force startupCheck to true for existing users who
-    // previously had it off. The startup scan is safe (~100ms, no token
-    // cost) and prevents silent format pollution between restarts. User
-    // can toggle off after this one-time migration.
-    if (savedData && savedData.startupCheck === false) {
-      this.settings.startupCheck = true;
-    }
-
-    // v1.20.0 migration: reset disableThinking from old default (true) to
-    // new default (false). Old behavior sent thinking.type='disabled' which
-    // caused HTTP 400 on many providers (OpenAI, Gemini, Ollama, etc.).
-    // New behavior: disableThinking=false means "don't send any thinking
-    // control field" — the provider decides its own default. This is safe
-    // for all providers and eliminates the 400 cascade. Users who
-    // explicitly want thinking control can re-enable it in Custom mode.
-    // Also reset advancedSettingsMode to 'default' so Custom-mode remnants
-    // (temperature, repetition_penalty, thinking toggle) don't leak into
-    // the new "provider decides" behavior.
-    if (savedData && savedData.disableThinking === true) {
-      this.settings.disableThinking = false;
-      this.settings.advancedSettingsMode = 'default';
-      console.debug('loadSettings: v1.20.0 migration — reset disableThinking to false, advancedSettingsMode to default');
+    // v1.18.3 migration REMOVED in v1.22.1 (#199). Previous code at this
+    // location unconditionally forced `savedData.startupCheck === false`
+    // back to `true` on every plugin load, silently undoing the user's
+    // toggle for ~2 years. Migration logic moved to
+    // `core/settings-migrations.ts` and then removed entirely. Anyone with
+    // `startupCheck: false` on disk today has explicitly chosen that
+    // value and we respect it.
+    //
+    // v1.20.0 migration (disableThinking default flip) now lives in
+    // `applySettingsMigrations`. See that file for the version-key gate.
+    if (applied.length > 0) {
+      console.debug(`loadSettings: applied migrations: ${applied.join(', ')}`);
     }
 
     // Migrate existing users: if they already have a working config, trust it

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,13 @@ export interface LLMWikiSettings {
   pageGenerationConcurrency: number;
   batchDelayMs: number;
 
+  // Migration markers — written by `core/settings-migrations.ts` so each
+  // version-keyed migration runs at most once. Keep these `boolean` and
+  // underscore-prefixed so they don't show up in the settings UI.
+  // (#199) The v1.18.3 startupCheck nudge was removed entirely; if a
+  // future migration re-nudges a value, gate it on one of these.
+  _migrated_v1_20_0_thinking?: boolean;
+
   // Query dedup
   lastOfferedQueryHash?: string;
 

--- a/src/ui/schema-diff-modal-classes.ts
+++ b/src/ui/schema-diff-modal-classes.ts
@@ -1,0 +1,51 @@
+// v1.22.1: Pure helper functions for the SchemaDiffModal class lifecycle.
+// Lives in its own file (no `obsidian` dep) so tests can import without
+// triggering Vite's import-analysis failure on the real Modal class.
+//
+// The CSS selector `.modal.llm-wiki-schema-diff-modal` sizes the outer
+// container; the inner class drives content-level styles
+// (`min-width: 720px`). Replaces the previous CSS `:has()` selector
+// (Obsidian review warning: `:has()` causes broad selector
+// invalidation → significant perf cost when content changes).
+
+export const DIFF_MODAL_CLASS = 'llm-wiki-schema-diff-modal';
+
+export interface DiffModalLike {
+  addClass: (cls: string) => void;
+  removeClass: (cls: string) => void;
+  empty: () => void;
+}
+
+/** Apply the modal-wide class to BOTH outer `.modal` and inner content. */
+export function applyDiffModalClasses(
+  modalEl: DiffModalLike,
+  contentEl: DiffModalLike,
+): void {
+  modalEl.addClass(DIFF_MODAL_CLASS);
+  contentEl.empty();
+  contentEl.addClass(DIFF_MODAL_CLASS);
+}
+
+/** Remove the outer modal class on close so it doesn't leak to the next modal. */
+export function removeDiffModalClasses(modalEl: DiffModalLike): void {
+  modalEl.removeClass(DIFF_MODAL_CLASS);
+}
+
+/**
+ * v1.22.0 #97: When the LLM reports `changes_needed=false`, the Modal
+ * should show the *current* schema in BOTH panes (left and right) so
+ * the user can read the schema as it stands today alongside the LLM's
+ * rationale. A blank right pane is confusing because the eye has
+ * nothing to anchor on.
+ *
+ * Implementation: the Modal constructor (or main.ts) normalizes empty-mode
+ * `newBody` to `currentBody` BEFORE lineDiff runs, so the resulting diff
+ * is all "eq" rows. Exported for unit testing in isolation.
+ */
+export function normalizeEmptyMode(opts: {
+  isEmpty: boolean;
+  currentBody: string;
+  newBody: string;
+}): string {
+  return opts.isEmpty ? opts.currentBody : opts.newBody;
+}

--- a/src/ui/schema-diff-modal.ts
+++ b/src/ui/schema-diff-modal.ts
@@ -29,6 +29,11 @@
 import { App, Modal } from 'obsidian';
 import { lineDiff } from '../core/diff';
 import { TEXTS } from '../texts';
+import {
+  applyDiffModalClasses,
+  normalizeEmptyMode,
+  removeDiffModalClasses,
+} from './schema-diff-modal-classes';
 
 export interface SchemaDiffModalOptions {
   currentBody: string;
@@ -161,9 +166,8 @@ export class SchemaDiffModal extends Modal {
     // i18n-parity.test.ts.
     const t = (TEXTS as unknown as Record<string, Record<string, string>>)[this.options.language ?? 'en']
       ?? TEXTS.en as unknown as Record<string, string>;
-    const { contentEl } = this;
-    contentEl.empty();
-    contentEl.addClass('llm-wiki-schema-diff-modal');
+    const { modalEl, contentEl } = this;
+    applyDiffModalClasses(modalEl, contentEl); // v1.22.1: width on outer .modal (was :has() selector)
 
     // Title
     contentEl.createEl('h2', { text: t.schemaDiffTitle ?? 'Schema update preview' });
@@ -344,6 +348,7 @@ export class SchemaDiffModal extends Modal {
   }
 
   onClose() {
+    removeDiffModalClasses(this.modalEl);
     this.contentEl.empty();
   }
 }
@@ -354,13 +359,7 @@ export class SchemaDiffModal extends Modal {
  * no awkward blank right pane. When not in empty mode, return the
  * LLM's proposed newBody verbatim.
  *
- * Exported for unit testing the invariant in isolation (the constructor
- * uses it too).
+ * NOTE: Implementation lives in `schema-diff-modal-classes.ts` so it can
+ * be unit-tested without triggering Vite's import-analysis on `obsidian`.
  */
-export function normalizeEmptyMode(opts: {
-  isEmpty: boolean;
-  currentBody: string;
-  newBody: string;
-}): string {
-  return opts.isEmpty ? opts.currentBody : opts.newBody;
-}
+export { normalizeEmptyMode } from './schema-diff-modal-classes';

--- a/src/wiki/lint/fix-dead-link.ts
+++ b/src/wiki/lint/fix-dead-link.ts
@@ -31,6 +31,62 @@ function replaceTargetLink(sourceContent: string, targetName: string, newLink: s
   );
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// #197 stub-content builders — honest placeholders, NOT LLM-filled stubs.
+//
+// Why these are pure functions: the LLM-stub-creating branch of fixDeadLink
+// used to call fillEmptyPage() after writing the empty stub. fillEmptyPage
+// runs the LLM against an empty page + a wiki index and asks for a fully
+// formed entity/concept page. With no real source note to anchor the
+// generation, the LLM fabricates alias claims, related-link targets, and a
+// summary that looks authoritative but is unsourced.
+//
+// Reintroduces the empty-source hallucination class that #164/#174 explicitly
+// gates in the ingest path. The lint path was a back door around the gate.
+//
+// v1.22.1 fix: stubs are honest placeholders. They carry the
+// `generation_complete: false` marker so #170's incomplete-cleaner recognises
+// them, and the placeholder body explicitly says the page is referenced but
+// not yet backed by a real source. A future real ingest fills the stub
+// through the normal ingest path, which IS gated by #164/#174.
+//
+// v1.23.0 extension: PPR engine will distinguish hub-in-waiting vs leaf-never-
+// hub dead links and decide whether to keep the stub, escalate to a full
+// ingest, or remove the stub and leave the dead link. The conservative
+// placeholder shape below does not block that evolution.
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface StubContentParams {
+  title: string;
+  stubType: 'entity' | 'concept';
+  wikiFolder: string;
+  /** Relative path inside the wiki folder of the page that referenced the target. */
+  referringPageRel: string;
+}
+
+export function buildStubContent(params: StubContentParams): string {
+  const { title, stubType, referringPageRel } = params;
+  const today = new Date().toISOString().split('T')[0];
+  const defaultTag = stubType === 'entity' ? 'other' : 'term';
+  return `---\ntype: ${stubType}\ncreated: ${today}\nsources: ["[[${referringPageRel}]]"]\ntags: [${defaultTag}]\ngeneration_complete: false\n---\n# ${title}\n\n> Stub created by Fix Dead Links — referenced by [[${referringPageRel}]]. Will be filled by next ingest of an actual source that defines this entity.\n`;
+}
+
+/**
+ * Policy gate for #197. The lint path MUST NOT hand a stub to fillEmptyPage()
+ * for an unresolvable dead link — that re-introduces the empty-source
+ * hallucination that #164/#174 was designed to prevent in the ingest path.
+ *
+ * Both branches return false today. The function exists as a single,
+ * greppable switch so any future PR that wants to re-introduce auto-fabrication
+ * has to change this gate explicitly (rather than slipping it past a review
+ * by editing a deep `await fillEmptyPage(...)` line).
+ */
+export function shouldFabricateStubForUnresolvableLink(_opts: {
+  branch: 'llm-create-stub' | 'deterministic-fallback';
+}): boolean {
+  return false;
+}
+
 export async function fixDeadLink(
   ctx: EngineContext,
   sourcePath: string,
@@ -149,17 +205,24 @@ export async function fixDeadLink(
     const stubSlug = slugify(sanitizedTitle, ctx.settings.slugCase === 'preserve');
     const stubPath = `${ctx.settings.wikiFolder}/${stubDir}/${stubSlug}.md`;
     const sourceRel = makeRelPath(sourcePath, ctx.settings.wikiFolder);
-    const stubContent = `---\ntype: ${stubType}\ncreated: ${new Date().toISOString().split('T')[0]}\nsources: ["[[${sourceRel}]]"]\ntags: [${stubType === 'entity' ? 'other' : 'term'}]\n---\n# ${sanitizedTitle}\n\n> Auto-generated stub page — referenced by [[${sourceRel}]].\n`;
+    // #197: stub is an honest placeholder, NOT LLM-filled. See buildStubContent
+    // for rationale. This prevents the empty-source hallucination class that
+    // #164/#174 gates in the ingest path.
+    const stubContent = buildStubContent({
+      title: sanitizedTitle,
+      stubType: stubType as 'entity' | 'concept',
+      wikiFolder: ctx.settings.wikiFolder,
+      referringPageRel: sourceRel,
+    });
 
     await ctx.createOrUpdateFile(stubPath, stubContent);
-    // Expand the stub with AI-generated content immediately.
-    const { fillEmptyPage } = await import('./fill-empty-page');
-    await fillEmptyPage(ctx, stubPath);
+    // #197: deliberately do NOT call fillEmptyPage here. See
+    // shouldFabricateStubForUnresolvableLink for the policy gate.
 
     const newLink = `[[${stubDir}/${stubSlug}|${sanitizedTitle}]]`;
     const updatedContent = replaceTargetLink(sourceContent, targetName, newLink);
     await ctx.createOrUpdateFile(sourcePath, updatedContent);
-    return `stub created and expanded: ${stubPath}`;
+    return `stub created (unfilled): ${stubPath} — will be filled by next ingest of a real source`;
   }
 
   // ---- Deterministic fallback when LLM fails ----
@@ -186,21 +249,31 @@ export async function fixDeadLink(
     return `fallback corrected: ${newLink}`;
   }
 
-  // No match — create a basic stub and expand it.
-  const cleanBasename = targetBasename.replace(/^(entities|concepts|sources)([^\s\-_a-zA-Z0-9])/, '$2');
-  const stubType = targetName.includes('/entities/') ? 'entity' : 'concept';
-  const stubDir = stubType === 'entity' ? WIKI_SUBFOLDERS.entities : WIKI_SUBFOLDERS.concepts;
-  const stubSlug = slugify(cleanBasename, ctx.settings.slugCase === 'preserve');
-  const stubPath = `${ctx.settings.wikiFolder}/${stubDir}/${stubSlug}.md`;
-  const sourceRel = makeRelPath(sourcePath, ctx.settings.wikiFolder);
-  const stubContent = `---\ntype: ${stubType}\ncreated: ${new Date().toISOString().split('T')[0]}\nsources: ["[[${sourceRel}]]"]\ntags: [${stubType === 'entity' ? 'other' : 'term'}]\n---\n# ${cleanBasename}\n\n> Auto-generated stub page — referenced by [[${sourceRel}]].\n`;
+  // No match — create an honest placeholder stub. Do NOT expand it via LLM.
+// #197: a dead link that doesn't resolve to any existing page is an honest
+// forward-reference. The user will eventually ingest a real source note that
+// defines the target, and at that point the normal ingest path (gated by
+// #164/#174) fills the stub through correct channels. Handing the stub to
+// fillEmptyPage() here would let the LLM fabricate alias claims and related
+// links against zero source content.
+const cleanBasename = targetBasename.replace(/^(entities|concepts|sources)([^\s\-_a-zA-Z0-9])/, '$2');
+const stubType: 'entity' | 'concept' = targetName.includes('/entities/') ? 'entity' : 'concept';
+const stubDir = stubType === 'entity' ? WIKI_SUBFOLDERS.entities : WIKI_SUBFOLDERS.concepts;
+const stubSlug = slugify(cleanBasename, ctx.settings.slugCase === 'preserve');
+const stubPath = `${ctx.settings.wikiFolder}/${stubDir}/${stubSlug}.md`;
+const sourceRel = makeRelPath(sourcePath, ctx.settings.wikiFolder);
+const stubContent = buildStubContent({
+  title: cleanBasename,
+  stubType,
+  wikiFolder: ctx.settings.wikiFolder,
+  referringPageRel: sourceRel,
+});
 
-  await ctx.createOrUpdateFile(stubPath, stubContent);
-  const { fillEmptyPage } = await import('./fill-empty-page');
-  await fillEmptyPage(ctx, stubPath);
+await ctx.createOrUpdateFile(stubPath, stubContent);
+// #197: deliberately do NOT call fillEmptyPage here.
 
-  const newLink = `[[${stubDir}/${stubSlug}|${cleanBasename}]]`;
-  const updatedContent = replaceTargetLink(sourceContent, targetName, newLink);
-  await ctx.createOrUpdateFile(sourcePath, updatedContent);
-  return `fallback stub created and expanded: ${stubPath}`;
+const newLink = `[[${stubDir}/${stubSlug}|${cleanBasename}]]`;
+const updatedContent = replaceTargetLink(sourceContent, targetName, newLink);
+await ctx.createOrUpdateFile(sourcePath, updatedContent);
+return `fallback stub created (unfilled): ${stubPath} — will be filled by next ingest of a real source`;
 }

--- a/styles.css
+++ b/styles.css
@@ -574,9 +574,11 @@
 }
 
 /* Obsidian's default modal width is too narrow for a side-by-side
- * diff. We target the modal-container that wraps our content via the
- * .llm-wiki-schema-diff-modal class (added to contentEl in onOpen). */
-.modal:has(.llm-wiki-schema-diff-modal) {
+ * diff. We target the modal-container via the .llm-wiki-schema-diff-modal
+ * class added to BOTH modalEl (outer .modal) and contentEl (inner content)
+ * in onOpen. Direct class selector avoids :has() (Obsidian review warning:
+ * :has causes broad selector invalidation → perf cost). */
+.modal.llm-wiki-schema-diff-modal {
   width: min(90vw, 1100px);
 }
 


### PR DESCRIPTION
Collects three PATCH fixes accumulated since v1.22.0:

- **#197 — fixDeadLink fabricates AI-expanded stub pages**: stop calling fillEmptyPage() in both stub-creating branches; stubs are now honest placeholders with generation_complete: false marker, identifiable by #170 incomplete-cleaner. Pure-function buildStubContent + policy gate shouldFabricateStubForUnresolvableLink() prevent re-introduction. Closes #197.
- **#199 — startupCheck always resets to true on restart**: remove the v1.18.3 migration that silently undid the user's choice on every load. Extract remaining migrations to core/settings-migrations.ts (pure function). Closes #199.
- **CSS :has() Obsidian review warning**: replace `.modal:has(.llm-wiki-schema-diff-modal)` with direct class selector. New scripts/css-lint.mjs to prevent regression. Wired into Gate 1.

All three fixes share the conservative v1.22.1 PATCH character: no new features, no schema changes, no breaking changes. Test count: 1029 passing (was 1012 in v1.22.0).

Refs #197, #199