### PR TITLE
docs: add Star History chart to all READMEs + editor discipline rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,9 +323,16 @@ Production code then simply uses `activeDocument` directly — no fallback, no e
 
 This rule exists because Obsidian's review ruleset is stricter than the local ESLint config. **Local `pnpm lint` passing does NOT guarantee Obsidian review will pass.**
 
-## ⚠️ Editor Discipline — No Bulk Scripts for Code
+## ⚠️ Editor Discipline — No Bulk Scripts for Code or Documents
 
-Every code change via `Read` + `Edit`. No sed/awk/python AST for code. (2026-06-11: a brace-matching script broke 3 sites that 4-Gate still passed — wrong lexical block in `query-engine.ts`, unsafe `this: any` in `lint-controller.ts`.)
+Every change via `Read` + `Edit` — no sed/awk/python for code or document editing. (2026-06-11: a brace-matching Python script broke 3 sites that 4-Gate still passed — wrong lexical block in `query-engine.ts`, unsafe `this: any` in `lint-controller.ts`.)
+
+### Document editing rules (2026-06-24 post-mortem)
+
+- **Read before Edit — always.** Know the exact surrounding context (5+ lines before/after) before constructing `old_string`. Never assume what's there from a grep match.
+- **Verify with `git diff` after every multi-file edit pass.** Check for unintended deletions — `Read` only shows the lines you asked for, not the lines your `old_string` accidentally consumed.
+- **grep alone is NOT sufficient for document editing.** A grep hit tells you *where* a pattern exists, not what surrounds it. Always follow grep with Read to see the full context, then construct Edit with exact line boundaries.
+- **Verify idempotency after every edit.** Check that surrounding content (especially the section that follows the insertion point) is intact — no swallowed trailing bullets, no broken headings. `git diff --stat` first, then `git diff` the file if any lines changed unexpectedly.
 
 ## ⚠️ Git Safety Protocol
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 - [🔒 Transparency & Compliance](#-transparency--compliance)
 - [📜 License](#-license)
 - [🙏 Acknowledgments](#-acknowledgments)
+- [Star History](#star-history)
 ---
 
 ## 💡 What is LLM-Wiki?
@@ -555,3 +556,7 @@ MIT License — see [LICENSE](LICENSE).
 - **💡 Concept:** [Andrej Karpathy's LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — the original vision that inspired this plugin
 - **🛠️ Platform:** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
 - **🔌 LLM transport:** Obsidian `requestUrl` (Anthropic) + handcrafted OpenAI-compatible HTTP client (3rd-party OpenAI-compatible providers)
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=top-left)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=top-left)

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -550,4 +550,6 @@ MIT License — 详见 [LICENSE](LICENSE)。
 - **🛠️ 开发平台：** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
 - **🔌 LLM 传输层：** Obsidian `requestUrl`（Anthropic）+ 手写的 OpenAI 兼容 HTTP 客户端（其他 OpenAI 兼容 Provider）
 
-**Closes:** #90 — Source 页面现在从源文件 frontmatter 继承 tags，而非 LLM 生成的概念名。
+## Star History
+
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=top-left)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=top-left)

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -530,8 +530,10 @@ MIT License — siehe [LICENSE](LICENSE).
 - **🛠️ Plattform:** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
 - **🔌 LLM-Transport:** Obsidian `requestUrl` (Anthropic) + handgeschriebener OpenAI-kompatibler HTTP-Client (3rd-Party OpenAI-kompatible Anbieter)
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=top-left)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=top-left)
+
 ---
 
 **Official Site:** [llmwiki.greenerai.top](https://llmwiki.greenerai.top/)
-
-**Closes:** #90 — Quellseiten erben Tags nun aus dem Frontmatter der Quellnotiz statt LLM-generierte Konzeptnamen zu verwenden.

--- a/docs/README_ES.md
+++ b/docs/README_ES.md
@@ -513,4 +513,6 @@ MIT License — consulta [LICENSE](LICENSE).
 - **🛠️ Plataforma:** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
 - **🔌 Transporte LLM:** `requestUrl` de Obsidian (Anthropic) + cliente HTTP compatible con OpenAI hecho a mano (proveedores terceros compatibles con OpenAI)
 
-**Closes:** #90 — Las páginas source ahora heredan tags del frontmatter de la nota source en lugar de nombres de conceptos generados por LLM.
+## Star History
+
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=top-left)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=top-left)

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -514,4 +514,6 @@ MIT License — voir [LICENSE](LICENSE).
 - **🛠️ Plateforme :** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
 - **🔌 Transport LLM :** `requestUrl` d'Obsidian (Anthropic) + client HTTP compatible OpenAI codé à la main (fournisseurs tiers compatibles OpenAI)
 
-**Closes:** #90 — Les pages source héritent désormais des tags du frontmatter de la note source au lieu de noms de concepts générés par LLM.
+## Star History
+
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=top-left)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=top-left)

--- a/docs/README_IT.md
+++ b/docs/README_IT.md
@@ -549,3 +549,7 @@ Licenza MIT — vedi [LICENSE](../LICENSE).
 - **💡 Concetto:** [LLM Wiki di Andrej Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — la visione originale che ha ispirato questo plugin
 - **🛠️ Piattaforma:** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
 - **🔌 Trasporto LLM:** `requestUrl` di Obsidian (Anthropic) + client HTTP compatibile con OpenAI scritto a mano (provider terzi compatibili con OpenAI)
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=top-left)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=top-left)

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -521,8 +521,10 @@ MIT License — [LICENSE](LICENSE)を参照
 - **🛠️ Platform:** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
 - **🔌 LLM transport:** Obsidian `requestUrl` (Anthropic) + 手書きの OpenAI 互換 HTTP クライアント（サードパーティ OpenAI 互換 Provider）
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=top-left)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=top-left)
+
 ---
 
 **公式サイト:** [llmwiki.greenerai.top](https://llmwiki.greenerai.top/)
-
-**Closes:** #90 — ソースページは LLM 生成のコンセプト名ではなく、ソースノートの frontmatter からタグを継承するようになりました。

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -521,8 +521,10 @@ MIT License — [LICENSE](LICENSE)를 참조하세요.
 - **🛠️ 플랫폼:** Obsidian 팀 — 플러그인 플랫폼 및 API
 - **🔌 LLM transport:** Obsidian `requestUrl` (Anthropic) + 직접 작성한 OpenAI 호환 HTTP 클라이언트 (3rd-party OpenAI 호환 Provider)
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=top-left)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=top-left)
+
 ---
 
 **공식 사이트:** [llmwiki.greenerai.top](https://llmwiki.greenerai.top/)
-
-**Closes:** #90 — Source 페이지가 이제 LLM 생성 컨셉 이름이 아닌 소스 노트 frontmatter에서 tags를 상속합니다.

--- a/docs/README_PT.md
+++ b/docs/README_PT.md
@@ -513,4 +513,6 @@ Licença MIT — veja [LICENSE](LICENSE).
 - **🛠️ Plataforma:** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
 - **🔌 Transporte LLM:** `requestUrl` do Obsidian (Anthropic) + cliente HTTP compatível com OpenAI escrito à mão (provedores terceiros compatíveis com OpenAI)
 
-**Closes:** #90 — As páginas source agora herdam tags do frontmatter da nota source em vez de nomes de conceitos gerados por LLM.
+## Star History
+
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=top-left)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=top-left)

--- a/docs/README_ZH-Hant.md
+++ b/docs/README_ZH-Hant.md
@@ -556,4 +556,6 @@ MIT License — 詳見 [LICENSE](LICENSE)。
 - **🛠️ 開發平臺：** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
 - **🔌 LLM 傳輸層：** Obsidian `requestUrl`（Anthropic）+ 手寫的 OpenAI 兼容 HTTP 客戶端（其他 OpenAI 兼容 Provider）
 
-**Closes:** #90 — Source 頁面現在從源文件 frontmatter 繼承 tags，而非 LLM 生成的概念名。
+## Star History
+
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=top-left)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=top-left)


### PR DESCRIPTION
Add Star History chart (star-history.com) to all 10 READMEs. Clean up pre-existing \`Closes: #90\` remnants. Extend Editor Discipline section in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)